### PR TITLE
(chore): add rust-cache to CI and use the standard uv action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Rust in GH runner images can lag behind stable releases + act does not include Rust
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
The current CI spontaneously broke, probably related to the uv 0.5.0 release