### PR TITLE
(fix): unuglify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ```{warning}
 ⚠️ The version of `zarr-python` we currently depend on is still in pre-release and this
 package is accordingly extremely experimental.
-We cannot guarantee any stability or correctness at the moment, 
-although we have tried to do extensive testing and make clear what we think we support and do not.
+We cannot guarantee any stability or correctness at the moment, although we have 
+tried to do extensive testing and make clear what we think we support and do not.
 ```
 
 This project serves as a bridge between [`zarrs`](https://docs.rs/zarrs/latest/zarrs/) and [`zarr`](https://zarr.readthedocs.io/en/latest/index.html) via [`PyO3`](https://pyo3.rs/v0.22.3/).  The main goal of the project is to speed up i/o.


### PR DESCRIPTION
This is a nice middle ground between the docs and the readme, I think:

<img width="711" alt="Screenshot 2024-11-16 at 10 15 09" src="https://github.com/user-attachments/assets/3a7a8c77-28e2-4c4b-b4cb-bdd93b7a4ad1">
<img width="856" alt="Screenshot 2024-11-16 at 10 15 22" src="https://github.com/user-attachments/assets/a8c88144-d80d-40d0-93bd-a7ef9e5add7b">
