### PR TITLE
(feat): balance chunk/codec concurrency internally and add configuration/concurrency docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ We export a `ZarrsCodecPipeline` class so that `zarr-python` can use the class b
 
 Standard `zarr.config` options control some functionality (see the defaults in the [config.py](https://github.com/zarr-developers/zarr-python/blob/main/src/zarr/core/config.py) of `zarr-python`):
 - `threading.num_workers`: the maximum number of threads used internally by the `ZarrsCodecPipeline` on the Rust side.
-- `async.concurrency`: the maximum number of chunks stored/retrieved concurrently.
-  - `threading.num_workers` and `async.concurrency` default to the number of threads in the global rayon thread pool if set to `None`, which is [typically the number of logical CPUs](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
+  - Defaults to the number of threads in the global `rayon` thread pool if set to `None`, which is [typically the number of logical CPUs](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
 - `array.write_empty_chunks`: whether or not to store empty chunks.
   - Defaults to false if `None`. Note that checking for emptiness has some overhead, see [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#store-empty-chunks) for more info.
   - This option name is proposed in [zarr-python #2429](https://github.com/zarr-developers/zarr-python/pull/2429)
 
 The `ZarrsCodecPipeline` specific options are:
+- `chunk_concurrent_maximum`: the maximum number of chunks stored/retrieved concurrently.
+  - Defaults to the number of logical CPUs if `None`. It is constrained by `threading.num_workers` as well.
 - `codec_pipeline.chunk_concurrent_minimum`: the minimum number of chunks retrieved/stored concurrently when balancing chunk/codec concurrency.
   - Defaults to 4 if `None`. See [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#chunk-concurrent-minimum) for more info
 - `codec_pipeline.validate_checksums`: enable checksum validation (e.g. with the CRC32C codec).
@@ -45,12 +46,12 @@ For example:
 ```python
 zarr.config.set({
     "threading.num_workers": None,
-    "async.concurrency": None,
     "array.write_empty_chunks": False,
     "codec_pipeline": {
         "path": "zarrs.ZarrsCodecPipeline",
         "validate_checksums": True,
         "store_empty_chunks": False,
+        "chunk_concurrent_maximum": None,
         "chunk_concurrent_minimum": 4,
     }
 })

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Standard `zarr.config` options control some functionality (see the defaults in t
   - This option name is proposed in [zarr-python #2429](https://github.com/zarr-developers/zarr-python/pull/2429)
 
 The `ZarrsCodecPipeline` specific options are:
-- `chunk_concurrent_maximum`: the maximum number of chunks stored/retrieved concurrently.
+- `codec_pipeline.chunk_concurrent_maximum`: the maximum number of chunks stored/retrieved concurrently.
   - Defaults to the number of logical CPUs if `None`. It is constrained by `threading.num_workers` as well.
 - `codec_pipeline.chunk_concurrent_minimum`: the minimum number of chunks retrieved/stored concurrently when balancing chunk/codec concurrency.
   - Defaults to 4 if `None`. See [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#chunk-concurrent-minimum) for more info

--- a/README.md
+++ b/README.md
@@ -28,14 +28,18 @@ We export a `ZarrsCodecPipeline` class so that `zarr-python` can use the class b
 `ZarrsCodecPipeline` options are exposed through `zarr.config`.
 
 Standard `zarr.config` options control some functionality (see the defaults in the [config.py](https://github.com/zarr-developers/zarr-python/blob/main/src/zarr/core/config.py) of `zarr-python`):
-- `threading.num_workers` (#threads if `None`): the maximum number of threads used internally by the `ZarrsCodecPipeline` on the Rust side.
-- `async.concurrency` (#threads if `None`): the maximum number of chunks stored/retrieved concurrently.
-- `array.write_empty_chunks` ([`False`](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#store-empty-chunks) if `None`): set whether or not to store empty chunks.
+- `threading.num_workers`: the maximum number of threads used internally by the `ZarrsCodecPipeline` on the Rust side.
+- `async.concurrency`: the maximum number of chunks stored/retrieved concurrently.
+  - `threading.num_workers` and `async.concurrency` default to the number of threads in the global rayon thread pool if set to `None`, which is [typically the number of logical CPUs](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads).
+- `array.write_empty_chunks`: whether or not to store empty chunks.
+  - Defaults to false if `None`. Note that checking for emptiness has some overhead, see [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#store-empty-chunks) for more info.
   - This option name is proposed in [zarr-python #2429](https://github.com/zarr-developers/zarr-python/pull/2429)
 
 The `ZarrsCodecPipeline` specific options are:
-- `codec_pipeline.chunk_concurrent_minimum` ([4](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#chunk-concurrent-minimum) if `None`): the minimum number of chunks retrieved/stored concurrently when balancing chunk/codec concurrency.
-- `codec_pipeline.validate_checksums` ([`True`](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#validate-checksums) if `None`): enable checksum validation (e.g. with the CRC32C codec).
+- `codec_pipeline.chunk_concurrent_minimum`: the minimum number of chunks retrieved/stored concurrently when balancing chunk/codec concurrency.
+  - Defaults to 4 if `None`. See [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#chunk-concurrent-minimum) for more info
+- `codec_pipeline.validate_checksums`: enable checksum validation (e.g. with the CRC32C codec).
+  - Defaults to true if `None`. See [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#validate-checksums) for more info.
 
 For example:
 ```python
@@ -55,18 +59,19 @@ zarr.config.set({
 ## Concurrency
 
 Concurrency can be classified into two types:
-- chunk (outer) concurrency: the number of chunks retrieved/stored concurrently, and
+- chunk (outer) concurrency: the number of chunks retrieved/stored concurrently.
+  - This is chosen automatically based on various factors, such as the chunk size and codecs.
+  - It is constrained between `codec_pipeline.chunk_concurrent_minimum` and `async.concurrency` for operations involving multiple chunks.
 - codec (inner) concurrency: the number of threads encoding/decoding a chunk.
+  - This is chosen automatically in combination with the chunk concurrency.
 
-`zarrs-python` automatically balances chunk and codec concurrency based on the chunk size and the codecs with constraints imposed by some of the options specified earlier.
+The product of the chunk and codec concurrency will approximately match `threading.num_workers`.
 
 Chunk concurrency is typically favored because:
 - parallel encoding/decoding can have a high overhead with some codecs, especially with small chunks, and
 - it is advantageous to retrieve/store multiple chunks concurrently, especially with high latency stores.
 
-Sharded arrays are one of the main exceptions.
-If encoding/decoding a shard (chunk) with many inner chunks, `zarrs-python` will favor codec concurrency over chunk concurrency.
-However, the number of concurrent chunks will not drop below the `codec_pipeline.chunk_concurrent_minimum`, unless `threading.num_workers` is lower.
+`zarrs-python` will often favor codec concurrency with sharded arrays, as they are well suited to codec concurrency.
 
 ## Supported Indexing Methods
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,50 @@ You can then use your `zarr` as normal (with some caveats)!
 
 We export a `ZarrsCodecPipeline` class so that `zarr-python` can use the class but it is not meant to be instantiated and we do not guarantee the stability of its API beyond what is required so that `zarr-python` can use it.  Therefore, it is not documented here.  We also export two errors, `DiscontiguousArrayError` and `CollapsedDimensionError` that can be thrown in the process of converting to indexers that `zarrs` can understand (see below for more details).
 
-There are two ways to control the concurrency of the i/o **TODO: Need to clarify this**
+### Configuration
+
+`ZarrsCodecPipeline` options are exposed through `zarr.config`.
+
+Standard `zarr.config` options control some functionality (see the defaults in the [config.py](https://github.com/zarr-developers/zarr-python/blob/main/src/zarr/core/config.py) of `zarr-python`):
+- `threading.num_workers` (#threads if `None`): the maximum number of threads used internally by the `ZarrsCodecPipeline` on the Rust side.
+- `async.concurrency` (#threads if `None`): the maximum number of chunks stored/retrieved concurrently.
+- `array.write_empty_chunks` ([`False`](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#store-empty-chunks) if `None`): set whether or not to store empty chunks.
+  - This option name is proposed in [zarr-python #2429](https://github.com/zarr-developers/zarr-python/pull/2429)
+
+The `ZarrsCodecPipeline` specific options are:
+- `codec_pipeline.chunk_concurrent_minimum` ([4](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#chunk-concurrent-minimum) if `None`): the minimum number of chunks retrieved/stored concurrently when balancing chunk/codec concurrency.
+- `codec_pipeline.validate_checksums` ([`True`](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#validate-checksums) if `None`): enable checksum validation (e.g. with the CRC32C codec).
+
+For example:
+```python
+zarr.config.set({
+    "threading.num_workers": None,
+    "async.concurrency": None,
+    "array.write_empty_chunks": False,
+    "codec_pipeline": {
+        "path": "zarrs.ZarrsCodecPipeline",
+        "validate_checksums": True,
+        "store_empty_chunks": False,
+        "chunk_concurrent_minimum": 4,
+    }
+})
+```
+
+## Concurrency
+
+Concurrency can be classified into two types:
+- chunk (outer) concurrency: the number of chunks retrieved/stored concurrently, and
+- codec (inner) concurrency: the number of threads encoding/decoding a chunk.
+
+`zarrs-python` automatically balances chunk and codec concurrency based on the chunk size and the codecs with constraints imposed by some of the options specified earlier.
+
+Chunk concurrency is typically favored because:
+- parallel encoding/decoding can have a high overhead with some codecs, especially with small chunks, and
+- it is advantageous to retrieve/store multiple chunks concurrently, especially with high latency stores.
+
+Sharded arrays are one of the main exceptions.
+If encoding/decoding a shard (chunk) with many inner chunks, `zarrs-python` will favor codec concurrency over chunk concurrency.
+However, the number of concurrent chunks will not drop below the `codec_pipeline.chunk_concurrent_minimum`, unless `threading.num_workers` is lower.
 
 ## Supported Indexing Methods
 

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -60,7 +60,9 @@ class ZarrsCodecPipeline(CodecPipeline):
                 chunk_concurrent_minimum=config.get(
                     "codec_pipeline.chunk_concurrent_minimum", None
                 ),
-                chunk_concurrent_maximum=config.get("async.concurrency", None),
+                chunk_concurrent_maximum=config.get(
+                    "codec_pipeline.chunk_concurrent_maximum", None
+                ),
                 num_threads=config.get("threading.max_workers", None),
             ),
         )

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,0 +1,51 @@
+use pyo3::{exceptions::PyRuntimeError, PyErr, PyResult};
+use zarrs::array::{
+    codec::CodecOptions, concurrency::calc_concurrency_outer_inner, ArrayCodecTraits,
+    RecommendedConcurrency,
+};
+
+use crate::{chunk_item::ChunksItem, CodecPipelineImpl};
+
+pub trait ChunkConcurrentLimitAndCodecOptions {
+    fn get_chunk_concurrent_limit_and_codec_options(
+        &self,
+        codec_pipeline_impl: &CodecPipelineImpl,
+    ) -> PyResult<Option<(usize, CodecOptions)>>;
+}
+
+impl<T> ChunkConcurrentLimitAndCodecOptions for Vec<T>
+where
+    T: ChunksItem,
+{
+    fn get_chunk_concurrent_limit_and_codec_options(
+        &self,
+        codec_pipeline_impl: &CodecPipelineImpl,
+    ) -> PyResult<Option<(usize, CodecOptions)>> {
+        let num_chunks = self.len();
+        let Some(chunk_descriptions0) = self.first() else {
+            return Ok(None);
+        };
+        let chunk_representation = chunk_descriptions0.representation();
+
+        let codec_concurrency = codec_pipeline_impl
+            .codec_chain
+            .recommended_concurrency(chunk_representation)
+            .map_err(|err| PyErr::new::<PyRuntimeError, _>(err.to_string()))?;
+
+        let min_concurrent_chunks =
+            std::cmp::min(codec_pipeline_impl.chunk_concurrent_minimum, num_chunks);
+        let max_concurrent_chunks =
+            std::cmp::max(codec_pipeline_impl.chunk_concurrent_maximum, num_chunks);
+        let (chunk_concurrent_limit, codec_concurrent_limit) = calc_concurrency_outer_inner(
+            codec_pipeline_impl.num_threads,
+            &RecommendedConcurrency::new(min_concurrent_chunks..max_concurrent_chunks),
+            &codec_concurrency,
+        );
+        let codec_options = codec_pipeline_impl
+            .codec_options
+            .into_builder()
+            .concurrent_target(codec_concurrent_limit)
+            .build();
+        Ok(Some((chunk_concurrent_limit, codec_options)))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,10 @@ use unsafe_cell_slice::UnsafeCellSlice;
 use zarrs::array::codec::{
     ArrayToBytesCodecTraits, CodecOptions, CodecOptionsBuilder, StoragePartialDecoder,
 };
+use zarrs::array::concurrency::calc_concurrency_outer_inner;
 use zarrs::array::{
-    copy_fill_value_into, update_array_bytes, ArrayBytes, ArraySize, CodecChain, FillValue,
+    copy_fill_value_into, update_array_bytes, ArrayBytes, ArrayCodecTraits, ArraySize,
+    ChunkRepresentation, CodecChain, FillValue, RecommendedConcurrency,
 };
 use zarrs::array_subset::ArraySubset;
 use zarrs::metadata::v3::MetadataV3;
@@ -40,6 +42,9 @@ pub struct CodecPipelineImpl {
     codec_chain: Arc<CodecChain>,
     store: Mutex<Option<Arc<dyn CodecPipelineStore>>>,
     codec_options: CodecOptions,
+    chunk_concurrent_minimum: usize,
+    chunk_concurrent_maximum: usize,
+    num_threads: usize
 }
 
 impl CodecPipelineImpl {
@@ -227,17 +232,51 @@ impl CodecPipelineImpl {
         };
         UnsafeCellSlice::new(output)
     }
+
+    fn concurrency_chunks_and_codec(
+        &self,
+        num_chunks: usize,
+        chunk_representation: &ChunkRepresentation,
+    ) -> PyResult<(usize, CodecOptions)> {
+        let codec_concurrency = self
+            .codec_chain
+            .recommended_concurrency(chunk_representation)
+            .map_err(|err| PyErr::new::<PyRuntimeError, _>(err.to_string()))?;
+
+        let min_concurrent_chunks = std::cmp::min(self.chunk_concurrent_minimum, num_chunks);
+        let max_concurrent_chunks = std::cmp::max(self.chunk_concurrent_maximum, num_chunks);
+        let (self_concurrent_limit, codec_concurrent_limit) = calc_concurrency_outer_inner(
+            self.num_threads,
+            &RecommendedConcurrency::new(min_concurrent_chunks..max_concurrent_chunks),
+            &codec_concurrency,
+        );
+        let codec_options = self
+            .codec_options
+            .into_builder()
+            .concurrent_target(codec_concurrent_limit)
+            .build();
+        Ok((self_concurrent_limit, codec_options))
+    }
 }
 
 #[pymethods]
 impl CodecPipelineImpl {
-    #[pyo3(signature = (metadata, validate_checksums=None, store_empty_chunks=None, concurrent_target=None))]
+    #[pyo3(signature = (
+        metadata,
+        validate_checksums=None,
+        store_empty_chunks=None,
+        chunk_concurrent_minimum=None,
+        chunk_concurrent_maximum=None,
+        num_threads=None,
+    ))]
     #[new]
     fn new(
         metadata: &str,
         validate_checksums: Option<bool>,
         store_empty_chunks: Option<bool>,
-        concurrent_target: Option<usize>,
+        chunk_concurrent_minimum: Option<usize>,
+        chunk_concurrent_maximum: Option<usize>,
+        num_threads: Option<usize>,
     ) -> PyResult<Self> {
         let metadata: Vec<MetadataV3> =
             serde_json::from_str(metadata).map_py_err::<PyTypeError>()?;
@@ -250,15 +289,21 @@ impl CodecPipelineImpl {
         if let Some(store_empty_chunks) = store_empty_chunks {
             codec_options = codec_options.store_empty_chunks(store_empty_chunks);
         }
-        if let Some(concurrent_target) = concurrent_target {
-            codec_options = codec_options.concurrent_target(concurrent_target);
-        }
         let codec_options = codec_options.build();
+
+        let chunk_concurrent_minimum = chunk_concurrent_minimum
+            .unwrap_or(zarrs::config::global_config().chunk_concurrent_minimum());
+        let chunk_concurrent_maximum = chunk_concurrent_maximum
+            .unwrap_or(rayon::current_num_threads());
+        let num_threads = num_threads.unwrap_or(rayon::current_num_threads());
 
         Ok(Self {
             codec_chain,
             store: Mutex::new(None),
             codec_options,
+            chunk_concurrent_minimum,
+            chunk_concurrent_maximum,
+            num_threads,
         })
     }
 
@@ -267,7 +312,6 @@ impl CodecPipelineImpl {
         py: Python,
         chunk_descriptions: Vec<chunk_item::RawWithIndices>, // FIXME: Ref / iterable?
         value: &Bound<'_, PyUntypedArray>,
-        chunk_concurrent_limit: usize,
     ) -> PyResult<()> {
         // Get input array
         if !value.is_c_contiguous() {
@@ -280,9 +324,16 @@ impl CodecPipelineImpl {
         let chunk_descriptions =
             self.collect_chunk_descriptions(chunk_descriptions, &output_shape)?;
 
-        py.allow_threads(move || {
-            let codec_options = &self.codec_options;
+        // Adjust the concurrency based on the codec chain and the first chunk description
+        let Some(chunk_descriptions0) = chunk_descriptions.first() else {
+            return Ok(());
+        };
+        let (chunk_concurrent_limit, codec_options) = self.concurrency_chunks_and_codec(
+            chunk_descriptions.len(),
+            chunk_descriptions0.representation(),
+        )?;
 
+        py.allow_threads(move || {
             let update_chunk_subset = |item: chunk_item::WithSubset| {
                 // See zarrs::array::Array::retrieve_chunk_subset_into
                 if item.chunk_subset.start().iter().all(|&o| o == 0)
@@ -303,7 +354,7 @@ impl CodecPipelineImpl {
                                 &output,
                                 &output_shape,
                                 &item.subset,
-                                codec_options,
+                                &codec_options,
                             )
                         }
                     } else {
@@ -334,7 +385,7 @@ impl CodecPipelineImpl {
                     let partial_decoder = self
                         .codec_chain
                         .clone()
-                        .partial_decoder(input_handle, item.representation(), codec_options)
+                        .partial_decoder(input_handle, item.representation(), &codec_options)
                         .map_py_err::<PyValueError>()?;
                     unsafe {
                         // SAFETY:
@@ -346,7 +397,7 @@ impl CodecPipelineImpl {
                             &output,
                             &output_shape,
                             &item.subset,
-                            codec_options,
+                            &codec_options,
                         )
                     }
                 }
@@ -368,13 +419,19 @@ impl CodecPipelineImpl {
         &self,
         py: Python<'py>,
         chunk_descriptions: Vec<chunk_item::Raw>, // FIXME: Ref / iterable?
-        chunk_concurrent_limit: usize,
     ) -> PyResult<Vec<Bound<'py, PyArray1<u8>>>> {
         let chunk_descriptions = self.collect_chunk_descriptions(chunk_descriptions, ())?;
 
-        let chunk_bytes = py.allow_threads(move || {
-            let codec_options = &self.codec_options;
+        // Adjust the concurrency based on the codec chain and the first chunk description
+        let Some(chunk_descriptions0) = chunk_descriptions.first() else {
+            return Ok(vec![]);
+        };
+        let (chunk_concurrent_limit, codec_options) = self.concurrency_chunks_and_codec(
+            chunk_descriptions.len(),
+            chunk_descriptions0.representation(),
+        )?;
 
+        let chunk_bytes = py.allow_threads(move || {
             let get_chunk_subset = |item: chunk_item::Basic| {
                 let chunk_encoded = item.get().map_py_err::<PyRuntimeError>()?;
                 Ok(if let Some(chunk_encoded) = chunk_encoded {
@@ -383,7 +440,7 @@ impl CodecPipelineImpl {
                         .decode(
                             Cow::Owned(chunk_encoded),
                             item.representation(),
-                            codec_options,
+                            &codec_options,
                         )
                         .map_py_err::<PyRuntimeError>()?
                 } else {
@@ -416,7 +473,6 @@ impl CodecPipelineImpl {
         py: Python,
         chunk_descriptions: Vec<chunk_item::RawWithIndices>,
         value: &Bound<'_, PyUntypedArray>,
-        chunk_concurrent_limit: usize,
     ) -> PyResult<()> {
         enum InputValue<'a> {
             Array(ArrayBytes<'a>),
@@ -441,9 +497,16 @@ impl CodecPipelineImpl {
         let chunk_descriptions =
             self.collect_chunk_descriptions(chunk_descriptions, &input_shape)?;
 
-        py.allow_threads(move || {
-            let codec_options = &self.codec_options;
+        // Adjust the concurrency based on the codec chain and the first chunk description
+        let Some(chunk_descriptions0) = chunk_descriptions.first() else {
+            return Ok(());
+        };
+        let (chunk_concurrent_limit, codec_options) = self.concurrency_chunks_and_codec(
+            chunk_descriptions.len(),
+            chunk_descriptions0.representation(),
+        )?;
 
+        py.allow_threads(move || {
             let store_chunk = |item: chunk_item::WithSubset| match &input {
                 InputValue::Array(input) => {
                     let chunk_subset_bytes = input
@@ -458,7 +521,7 @@ impl CodecPipelineImpl {
                         &self.codec_chain,
                         chunk_subset_bytes,
                         &item.chunk_subset,
-                        codec_options,
+                        &codec_options,
                     )
                 }
                 InputValue::Constant(constant_value) => {
@@ -475,7 +538,7 @@ impl CodecPipelineImpl {
                         &self.codec_chain,
                         chunk_subset_bytes,
                         &item.chunk_subset,
-                        codec_options,
+                        &codec_options,
                     )
                 }
             };


### PR DESCRIPTION
This adds some of the functionality that is used internally in `zarrs` itself for balancing chunk/codec concurrency.

Overall, this doesn't make much of a difference in benchmarks with `zarrs-python`, but it does reduce memory usage in some sharding benchmarks.