### PR TITLE
Use GitHub markdown alert extension for warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # zarrs-python
 
-```{warning}
-⚠️ The version of `zarr-python` we currently depend on is still in pre-release and this
-package is accordingly extremely experimental.
-We cannot guarantee any stability or correctness at the moment, although we have 
-tried to do extensive testing and make clear what we think we support and do not.
-```
+> [!WARNING]
+> The current `zarr-python` version we depend on is still in pre-release and this
+> package is accordingly extremely experimental. API stability and correctness
+> are not guaranteed, though we’ve tried to test extensively and clarify supported
+> features.
 
 This project serves as a bridge between [`zarrs`](https://docs.rs/zarrs/latest/zarrs/) and [`zarr`](https://zarr.readthedocs.io/en/latest/index.html) via [`PyO3`](https://pyo3.rs/v0.22.3/).  The main goal of the project is to speed up i/o.
 


### PR DESCRIPTION
I assume the intent of the warning code block was: https://github.com/orgs/community/discussions/16925

Also tried to clarify the text.