### PR TITLE
chore(deps): bump zarrs to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "zarrs"
-version = "0.18.0-beta.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf2268e57ea21ebb30abee0f5707a73d59b3ee822d8cd92dffd4230286ea6af"
+checksum = "a2957fbdc365a192c71fe61ab2e759d4e77fbad598e032102b87b4188c32369d"
 dependencies = [
  "blosc-src",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.22.6", features = ["abi3-py311"] }
-zarrs = "0.18.0-beta.0"
+zarrs = "0.18.0"
 rayon_iter_concurrent_limit = "0.2.0"
 rayon = "1.10.0"
 # fix for https://stackoverflow.com/questions/76593417/package-openssl-was-not-found-in-the-pkg-config-search-path


### PR DESCRIPTION
No relevant API changes since 0.18.0-beta.0