### PR TITLE
Instantiate Rust containers from Python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ pyo3-stub-gen = "0.6.1"
 opendal = { version = "0.50.2", features = ["services-http"] }
 tokio = { version = "1.41.1", features = ["rt-multi-thread"] }
 zarrs_opendal = "0.4.0"
-arc_map = "0.1.3"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pyo3-stub-gen = "0.6.1"
 opendal = { version = "0.50.2", features = ["services-http"] }
 tokio = { version = "1.41.1", features = ["rt-multi-thread"] }
 zarrs_opendal = "0.4.0"
+arc_map = "0.1.3"
 
 [profile.release]
 lto = true

--- a/python/zarrs/_internal.pyi
+++ b/python/zarrs/_internal.pyi
@@ -21,32 +21,17 @@ class CodecPipelineImpl:
     def retrieve_chunks_and_apply_index(
         self,
         chunk_descriptions: typing.Sequence[
-            tuple[
-                tuple[
-                    StoreConfig, str, typing.Sequence[int], str, typing.Sequence[int]
-                ],
-                typing.Sequence[slice],
-                typing.Sequence[slice],
-            ]
+            tuple[Raw, typing.Sequence[slice], typing.Sequence[slice]]
         ],
         value: numpy.NDArray[typing.Any],
     ) -> None: ...
     def retrieve_chunks(
-        self,
-        chunk_descriptions: typing.Sequence[
-            tuple[StoreConfig, str, typing.Sequence[int], str, typing.Sequence[int]]
-        ],
+        self, chunk_descriptions: typing.Sequence[Raw]
     ) -> list[numpy.typing.NDArray[numpy.uint8]]: ...
     def store_chunks_with_indices(
         self,
         chunk_descriptions: typing.Sequence[
-            tuple[
-                tuple[
-                    StoreConfig, str, typing.Sequence[int], str, typing.Sequence[int]
-                ],
-                typing.Sequence[slice],
-                typing.Sequence[slice],
-            ]
+            tuple[Raw, typing.Sequence[slice], typing.Sequence[slice]]
         ],
         value: numpy.NDArray[typing.Any],
     ) -> None: ...
@@ -56,6 +41,17 @@ class FilesystemStoreConfig:
 
 class HttpStoreConfig:
     endpoint: str
+
+class Raw:
+    def __new__(
+        cls,
+        store: StoreConfig,
+        path: str,
+        chunk_shape: typing.Sequence[int],
+        dtype: str,
+        fill_value: typing.Sequence[int],
+    ): ...
+    ...
 
 class StoreConfig(Enum):
     Filesystem = auto()

--- a/python/zarrs/_internal.pyi
+++ b/python/zarrs/_internal.pyi
@@ -7,6 +7,10 @@ from enum import Enum, auto
 import numpy
 import numpy.typing
 
+class Basic:
+    def __new__(cls, byte_interface: typing.Any, chunk_spec: typing.Any): ...
+    ...
+
 class CodecPipelineImpl:
     def __new__(
         cls,
@@ -20,19 +24,15 @@ class CodecPipelineImpl:
     ): ...
     def retrieve_chunks_and_apply_index(
         self,
-        chunk_descriptions: typing.Sequence[
-            tuple[Raw, typing.Sequence[slice], typing.Sequence[slice]]
-        ],
+        chunk_descriptions: typing.Sequence[WithSubset],
         value: numpy.NDArray[typing.Any],
     ) -> None: ...
     def retrieve_chunks(
-        self, chunk_descriptions: typing.Sequence[Raw]
+        self, chunk_descriptions: typing.Sequence[Basic]
     ) -> list[numpy.typing.NDArray[numpy.uint8]]: ...
     def store_chunks_with_indices(
         self,
-        chunk_descriptions: typing.Sequence[
-            tuple[Raw, typing.Sequence[slice], typing.Sequence[slice]]
-        ],
+        chunk_descriptions: typing.Sequence[WithSubset],
         value: numpy.NDArray[typing.Any],
     ) -> None: ...
 
@@ -42,14 +42,13 @@ class FilesystemStoreConfig:
 class HttpStoreConfig:
     endpoint: str
 
-class Raw:
+class WithSubset:
     def __new__(
         cls,
-        store: StoreConfig,
-        path: str,
-        chunk_shape: typing.Sequence[int],
-        dtype: str,
-        fill_value: typing.Sequence[int],
+        item: Basic,
+        chunk_subset: typing.Sequence[slice],
+        subset: typing.Sequence[slice],
+        shape: typing.Sequence[int],
     ): ...
     ...
 

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -117,10 +117,11 @@ class ZarrsCodecPipeline(CodecPipeline):
         batch_info: Iterable[
             tuple[ByteGetter, ArraySpec, SelectorTuple, SelectorTuple]
         ],
-        out: NDBuffer,
+        out: NDBuffer,  # type: ignore
         drop_axes: tuple[int, ...] = (),  # FIXME: unused
     ) -> None:
-        out = out.as_ndarray_like()  # FIXME: Error if array is not in host memory
+        # FIXME: Error if array is not in host memory
+        out: NDArrayLike = out.as_ndarray_like()
         if not out.dtype.isnative:
             raise RuntimeError("Non-native byte order not supported")
         try:
@@ -149,7 +150,7 @@ class ZarrsCodecPipeline(CodecPipeline):
         batch_info: Iterable[
             tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple]
         ],
-        value: NDBuffer,
+        value: NDBuffer,  # type: ignore
         drop_axes: tuple[int, ...] = (),
     ) -> None:
         # FIXME: Error if array is not in host memory

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -137,10 +137,7 @@ class ZarrsCodecPipeline(CodecPipeline):
             )
             return None
         chunks = await asyncio.to_thread(self.impl.retrieve_chunks, chunks_desc)
-        for chunk, chunk_info in zip(chunks, batch_info):
-            out_selection = chunk_info[3]
-            selection = chunk_info[2]
-            spec = chunk_info[1]
+        for chunk, (_, spec, selection, out_selection) in zip(chunks, batch_info):
             chunk_reshaped = chunk.view(spec.dtype).reshape(spec.shape)
             chunk_selected = chunk_reshaped[selection]
             if drop_axes:

--- a/python/zarrs/utils.py
+++ b/python/zarrs/utils.py
@@ -162,9 +162,9 @@ def make_chunk_info_for_rust_with_indices(
         chunk_info_with_indices.append(
             WithSubset(
                 chunk_info,
-                out_selection_as_slices,
-                chunk_selection_as_slices,
-                shape,
+                chunk_subset=chunk_selection_as_slices,
+                subset=out_selection_as_slices,
+                shape=shape,
             )
         )
     return chunk_info_with_indices

--- a/python/zarrs/utils.py
+++ b/python/zarrs/utils.py
@@ -141,6 +141,7 @@ def make_chunk_info_for_rust_with_indices(
     drop_axes: tuple[int, ...],
     shape: tuple[int, ...],
 ) -> list[WithSubset]:
+    shape = shape if shape else (1,)  # constant array
     chunk_info_with_indices: list[WithSubset] = []
     for byte_getter, chunk_spec, chunk_selection, out_selection in batch_info:
         chunk_info = Basic(byte_getter, chunk_spec)

--- a/src/chunk_item.rs
+++ b/src/chunk_item.rs
@@ -75,7 +75,8 @@ impl WithSubset {
         subset: Vec<Bound<'_, PySlice>>,
         shape: Vec<u64>,
     ) -> PyResult<Self> {
-        let chunk_subset = selection_to_array_subset(&chunk_subset, &shape)?;
+        let chunk_subset =
+            selection_to_array_subset(&chunk_subset, &item.representation.shape_u64())?;
         let subset = selection_to_array_subset(&subset, &shape)?;
         Ok(Self {
             item,

--- a/src/chunk_item.rs
+++ b/src/chunk_item.rs
@@ -40,8 +40,14 @@ impl Basic {
         let path: String = byte_interface.getattr("path")?.extract()?;
 
         let chunk_shape = chunk_spec.getattr("shape")?.extract()?;
-        let dtype: String = chunk_spec.getattr("dtype")?.call_method0("__str__")?.extract()?;
-        let fill_value = chunk_spec.getattr("fill_value")?.call_method0("tobytes")?.extract()?;
+        let dtype: String = chunk_spec
+            .getattr("dtype")?
+            .call_method0("__str__")?
+            .extract()?;
+        let fill_value = chunk_spec
+            .getattr("fill_value")?
+            .call_method0("tobytes")?
+            .extract()?;
         Ok(Self {
             store,
             key: StoreKey::new(path).map_py_err::<PyValueError>()?,

--- a/src/chunk_item.rs
+++ b/src/chunk_item.rs
@@ -14,7 +14,7 @@ use zarrs::{
 
 use crate::{utils::PyErrExt, StoreConfig};
 
-pub(crate) type Raw<'a> = (
+pub(crate) type Raw = (
     // store
     StoreConfig,
     // path
@@ -28,7 +28,7 @@ pub(crate) type Raw<'a> = (
 );
 
 pub(crate) type RawWithIndices<'a> = (
-    Raw<'a>,
+    Raw,
     // out selection
     Vec<Bound<'a, PySlice>>,
     // chunk selection
@@ -92,7 +92,7 @@ impl ChunksItem for WithSubset {
     }
 }
 
-impl IntoItem<Basic, ()> for Raw<'_> {
+impl IntoItem<Basic, ()> for Raw {
     fn store_config(&self) -> &StoreConfig {
         &self.0
     }

--- a/src/chunk_item.rs
+++ b/src/chunk_item.rs
@@ -92,7 +92,7 @@ impl ChunksItem for WithSubset {
     }
 }
 
-impl<'a> IntoItem<Basic, ()> for Raw<'a> {
+impl IntoItem<Basic, ()> for Raw<'_> {
     fn store_config(&self) -> &StoreConfig {
         &self.0
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,6 +526,7 @@ impl CodecPipelineImpl {
 fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<CodecPipelineImpl>()?;
+    m.add_class::<chunk_item::Raw>()?;
     Ok(())
 }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -19,6 +19,7 @@ use crate::{runtime::tokio_block_on, utils::PyErrExt};
 mod filesystem;
 mod http;
 
+#[derive(Debug, Clone)]
 #[gen_stub_pyclass_enum]
 pub enum StoreConfig {
     Filesystem(FilesystemStoreConfig),

--- a/src/store.rs
+++ b/src/store.rs
@@ -19,7 +19,7 @@ use crate::{runtime::tokio_block_on, utils::PyErrExt};
 mod filesystem;
 mod http;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[gen_stub_pyclass_enum]
 pub enum StoreConfig {
     Filesystem(FilesystemStoreConfig),

--- a/src/store/filesystem.rs
+++ b/src/store/filesystem.rs
@@ -6,7 +6,7 @@ use zarrs::{filesystem::FilesystemStore, storage::ReadableWritableListableStorag
 
 use crate::utils::PyErrExt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[gen_stub_pyclass]
 #[pyclass]
 pub struct FilesystemStoreConfig {

--- a/src/store/http.rs
+++ b/src/store/http.rs
@@ -6,7 +6,7 @@ use zarrs::storage::ReadableWritableListableStorage;
 
 use super::opendal_builder_to_sync_store;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[gen_stub_pyclass]
 #[pyclass]
 pub struct HttpStoreConfig {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+use pyo3::ffi::c_str;
+
 use numpy::PyUntypedArray;
 use pyo3::{
     types::{PyAnyMethods, PyModule},
@@ -10,13 +12,13 @@ use crate::CodecPipelineImpl;
 fn test_nparray_to_unsafe_cell_slice_empty() -> PyResult<()> {
     pyo3::prepare_freethreaded_python();
     Python::with_gil(|py| {
-        let arr: Bound<'_, PyUntypedArray> = PyModule::from_code_bound(
+        let arr: Bound<'_, PyUntypedArray> = PyModule::from_code(
             py,
-            "def empty_array():
+            c_str!("def empty_array():
                 import numpy as np
-                return np.empty(0, dtype=np.uint8)",
-            "",
-            "",
+                return np.empty(0, dtype=np.uint8)"),
+                c_str!(""),
+                c_str!(""),
         )?
         .getattr("empty_array")?
         .call0()?

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,11 +14,13 @@ fn test_nparray_to_unsafe_cell_slice_empty() -> PyResult<()> {
     Python::with_gil(|py| {
         let arr: Bound<'_, PyUntypedArray> = PyModule::from_code(
             py,
-            c_str!("def empty_array():
+            c_str!(
+                "def empty_array():
                 import numpy as np
-                return np.empty(0, dtype=np.uint8)"),
-                c_str!(""),
-                c_str!(""),
+                return np.empty(0, dtype=np.uint8)"
+            ),
+            c_str!(""),
+            c_str!(""),
         )?
         .getattr("empty_array")?
         .call0()?


### PR DESCRIPTION
OK, I think I’m mostly there!

I don’t know where I made an error, could you maybe take a look @LDeakin?

TODO:

- [ ] Maybe we need to improve performance of Basic: It currently contains a StoreConfig, and on each access locks the hashmap. We should probably keep the previous behavior of having `Arc`s in there which is probably faster