### PR TITLE
fix: cleanup internal `nparray_to_*` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,8 +158,8 @@ impl CodecPipelineImpl {
         value: &'a Bound<'_, PyUntypedArray>,
     ) -> &'a PyArrayObject {
         let array_object_ptr: *mut PyArrayObject = value.as_array_ptr();
-        let array_object: &PyArrayObject = unsafe {
-            // SAFETY: array_object_ptr cannot be null
+        let array_object: &'a PyArrayObject = unsafe {
+            // SAFETY: array_object_ptr cannot be null and the array object pointed to by array_object_ptr is valid for 'a
             array_object_ptr
                 .as_ref()
                 .expect("pointer is convertible to a reference")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ impl CodecPipelineImpl {
     }
 
     fn py_untyped_array_to_array_object<'a>(
-        value: &Bound<'a, PyUntypedArray>,
+        value: &'a Bound<'_, PyUntypedArray>,
     ) -> &'a PyArrayObject {
         let array_object_ptr: *mut PyArrayObject = value.as_array_ptr();
         let array_object: &PyArrayObject = unsafe {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -26,7 +26,7 @@ fn test_nparray_to_unsafe_cell_slice_empty() -> PyResult<()> {
         .call0()?
         .extract()?;
 
-        let slice = CodecPipelineImpl::nparray_to_unsafe_cell_slice(&arr);
+        let slice = CodecPipelineImpl::nparray_to_unsafe_cell_slice(&arr)?;
         assert!(slice.is_empty());
         Ok(())
     })


### PR DESCRIPTION
Addresses #78. I don't think there is/was any unsoundness, but doesn't hurt to get more eyes on it. `nparray_to_slice` and `nparray_to_unsafe_cell_slice` now validate internally.