### PR TITLE
fix: compatibility with `zarr-python` 3.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     'donfig',
     'pytest',
     'universal_pathlib>=0.2.0',
-    "zarr",
+    "zarr>=3.0.3",
 ]
 
 [project.optional-dependencies]

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -155,7 +155,7 @@ class ZarrsCodecPipeline(CodecPipeline):
     async def read(
         self,
         batch_info: Iterable[
-            tuple[ByteGetter, ArraySpec, SelectorTuple, SelectorTuple]
+            tuple[ByteGetter, ArraySpec, SelectorTuple, SelectorTuple, bool]
         ],
         out: NDBuffer,  # type: ignore
         drop_axes: tuple[int, ...] = (),  # FIXME: unused
@@ -191,7 +191,7 @@ class ZarrsCodecPipeline(CodecPipeline):
     async def write(
         self,
         batch_info: Iterable[
-            tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple]
+            tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple, bool]
         ],
         value: NDBuffer,  # type: ignore
         drop_axes: tuple[int, ...] = (),
@@ -229,13 +229,13 @@ class ZarrsCodecPipeline(CodecPipeline):
     def _raise_error_on_unsupported_batch_dtype(
         self,
         batch_info: Iterable[
-            tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple]
+            tuple[ByteSetter, ArraySpec, SelectorTuple, SelectorTuple, bool]
         ],
     ):
         # https://github.com/LDeakin/zarrs/blob/0532fe983b7b42b59dbf84e50a2fe5e6f7bad4ce/zarrs_metadata/src/v2_to_v3.rs#L289-L293 for VSUMm
         # Further, our pipeline does not support variable-length objects due to limitations on decode_into, so object is also out
         if any(
             info.dtype.kind in {"V", "S", "U", "M", "m", "O"}
-            for (_, info, _, _) in batch_info
+            for (_, info, _, _, _) in batch_info
         ):
             raise UnsupportedDataTypeError()

--- a/python/zarrs/utils.py
+++ b/python/zarrs/utils.py
@@ -159,7 +159,7 @@ def make_chunk_info_for_rust_with_indices(
         chunk_spec,
         chunk_selection,
         out_selection,
-        _is_complete,
+        _,
     ) in batch_info:
         if chunk_spec.fill_value is None:
             chunk_spec = ArraySpec(

--- a/python/zarrs/utils.py
+++ b/python/zarrs/utils.py
@@ -147,14 +147,20 @@ def get_implicit_fill_value(dtype: np.dtype, fill_value: Any) -> Any:
 
 def make_chunk_info_for_rust_with_indices(
     batch_info: Iterable[
-        tuple[ByteGetter | ByteSetter, ArraySpec, SelectorTuple, SelectorTuple]
+        tuple[ByteGetter | ByteSetter, ArraySpec, SelectorTuple, SelectorTuple, bool]
     ],
     drop_axes: tuple[int, ...],
     shape: tuple[int, ...],
 ) -> list[WithSubset]:
     shape = shape if shape else (1,)  # constant array
     chunk_info_with_indices: list[WithSubset] = []
-    for byte_getter, chunk_spec, chunk_selection, out_selection in batch_info:
+    for (
+        byte_getter,
+        chunk_spec,
+        chunk_selection,
+        out_selection,
+        _is_complete,
+    ) in batch_info:
         if chunk_spec.fill_value is None:
             chunk_spec = ArraySpec(
                 chunk_spec.shape,


### PR DESCRIPTION
`zarr-python` 3.0.3 changed the `CodecPipeline` API a little in https://github.com/zarr-developers/zarr-python/pull/2784.