### PR TITLE
(chore): release `0.1.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarrs-python"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
I think this is an important release because our current `pip install` is broken without it