### PR TITLE
(fix): check for `T` data type `kind` to fall back to python

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,10 +59,10 @@ jobs:
             # If we're running on rhel centos, install needed packages.
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core
-            fi
-            # https://github.com/PyO3/maturin-action/discussions/152
-            if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.target }}" == "x86_64" && "${{ matrix.manylinux }}" == "2_28" ]]; then
-                apt update -y && apt install -y clang
+              # https://github.com/PyO3/maturin-action/discussions/152
+              if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.target }}" == "x86_64" && "${{ matrix.manylinux }}" == "2_28" ]]; then
+                  yum update -y && yum install -y clang
+              fi
             fi
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
       - run: twine check --strict dist/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,10 +59,10 @@ jobs:
             # If we're running on rhel centos, install needed packages.
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core
-              # https://github.com/PyO3/maturin-action/discussions/152
-              if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.target }}" == "x86_64" && "${{ matrix.manylinux }}" == "2_28" ]]; then
-                  yum update -y && yum install -y clang
-              fi
+                # https://github.com/PyO3/maturin-action/discussions/152
+                if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.target }}" == "x86_64" && "${{ matrix.manylinux }}" == "2_28" ]]; then
+                    yum update -y && yum install -y clang
+                fi
             fi
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
       - run: twine check --strict dist/*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,10 @@ jobs:
             if command -v yum &> /dev/null; then
                 yum update -y && yum install -y perl-core
             fi
+            # https://github.com/PyO3/maturin-action/discussions/152
+            if [[ "${{ matrix.os }}" == "linux" && "${{ matrix.target }}" == "x86_64" && "${{ matrix.manylinux }}" == "2_28" ]]; then
+                apt update -y && apt install -y clang
+            fi
       - run: ${{ (matrix.os == 'windows' && 'dir') || 'ls -lh' }} dist/
       - run: twine check --strict dist/*
       - uses: actions/upload-artifact@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   apt_packages:
     - clang
   tools:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: ubuntu-22.04
   apt_packages:
-    - libclang
+    - clang
   tools:
     python: "3.12"
     rust: "latest"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,8 @@
 version: 2
 build:
   os: ubuntu-22.04
+  apt_packages:
+    - libclang
   tools:
     python: "3.12"
     rust: "latest"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.12"
     rust: "latest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ filterwarnings = [
     "ignore:The loop argument is deprecated since Python 3.8.*:DeprecationWarning",
     "ignore:Creating a zarr.buffer.gpu.*:UserWarning",
     "ignore:Duplicate name:UserWarning",                                            # from ZipFile
+    "ignore:.*not part in the Zarr format 3.*:UserWarning",
 ]
 markers = ["gpu: mark a test as requiring CuPy and GPU"]
 

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -233,9 +233,9 @@ class ZarrsCodecPipeline(CodecPipeline):
         ],
     ):
         # https://github.com/LDeakin/zarrs/blob/0532fe983b7b42b59dbf84e50a2fe5e6f7bad4ce/zarrs_metadata/src/v2_to_v3.rs#L289-L293 for VSUMm
-        # Further, our pipeline does not support variable-length objects due to limitations on decode_into, so object is also out
+        # Further, our pipeline does not support variable-length objects due to limitations on decode_into, so object/np.dtypes.StringDType is also out
         if any(
-            info.dtype.kind in {"V", "S", "U", "M", "m", "O"}
+            info.dtype.kind in {"V", "S", "U", "M", "m", "O", "T"}
             for (_, info, _, _, _) in batch_info
         ):
             raise UnsupportedDataTypeError()

--- a/tests/test_vlen.py
+++ b/tests/test_vlen.py
@@ -10,8 +10,6 @@ from zarr.core.metadata.v3 import ArrayV3Metadata, DataType
 from zarr.core.strings import _NUMPY_SUPPORTS_VLEN_STRING
 from zarr.storage import StorePath
 
-pytest.skip(allow_module_level=True)
-
 numpy_str_dtypes: list[type | str | None] = [None, str, "str", np.dtypes.StrDType]
 expected_zarr_string_dtype: np.dtype[Any]
 if _NUMPY_SUPPORTS_VLEN_STRING:
@@ -21,7 +19,7 @@ else:
     expected_zarr_string_dtype = np.dtype("O")
 
 
-@pytest.mark.parametrize("store", ["memory", "local"], indirect=["store"])
+@pytest.mark.parametrize("store", ["local"], indirect=["store"])
 @pytest.mark.parametrize("dtype", numpy_str_dtypes)
 @pytest.mark.parametrize("as_object_array", [False, True])
 @pytest.mark.parametrize(

--- a/tests/test_vlen.py
+++ b/tests/test_vlen.py
@@ -2,10 +2,10 @@ from typing import Any
 
 import numpy as np
 import pytest
-from zarr import Array
+import zarr
 from zarr.abc.codec import Codec
 from zarr.abc.store import Store
-from zarr.codecs import VLenBytesCodec, VLenUTF8Codec, ZstdCodec
+from zarr.codecs import ZstdCodec
 from zarr.core.metadata.v3 import ArrayV3Metadata, DataType
 from zarr.core.strings import _NUMPY_SUPPORTS_VLEN_STRING
 from zarr.storage import StorePath
@@ -22,27 +22,25 @@ else:
 @pytest.mark.parametrize("store", ["local"], indirect=["store"])
 @pytest.mark.parametrize("dtype", numpy_str_dtypes)
 @pytest.mark.parametrize("as_object_array", [False, True])
-@pytest.mark.parametrize(
-    "codecs", [None, [VLenUTF8Codec()], [VLenUTF8Codec(), ZstdCodec()]]
-)
+@pytest.mark.parametrize("compressor", [None, ZstdCodec()])
 def test_vlen_string(
-    *,
     store: Store,
-    dtype: None | np.dtype[Any],
+    dtype: np.dtype[Any] | None,
+    *,
     as_object_array: bool,
-    codecs: None | list[Codec],
+    compressor: Codec | None,
 ) -> None:
     strings = ["hello", "world", "this", "is", "a", "test"]
     data = np.array(strings, dtype=dtype).reshape((2, 3))
 
     sp = StorePath(store, path="string")
-    a = Array.create(
+    a = zarr.create_array(
         sp,
         shape=data.shape,
-        chunk_shape=data.shape,
+        chunks=data.shape,
         dtype=data.dtype,
         fill_value="",
-        codecs=codecs,
+        compressors=compressor,
     )
     assert isinstance(a.metadata, ArrayV3Metadata)  # needed for mypy
 
@@ -57,33 +55,31 @@ def test_vlen_string(
     assert a.dtype == expected_zarr_string_dtype
 
     # test round trip
-    b = Array.open(sp)
+    b = zarr.open(sp)
     assert isinstance(b.metadata, ArrayV3Metadata)  # needed for mypy
     assert np.array_equal(data, b[:, :])
     assert b.metadata.data_type == DataType.string
     assert a.dtype == expected_zarr_string_dtype
 
 
-@pytest.mark.parametrize("store", ["memory", "local"], indirect=["store"])
+@pytest.mark.parametrize("store", ["local"], indirect=["store"])
 @pytest.mark.parametrize("as_object_array", [False, True])
-@pytest.mark.parametrize(
-    "codecs", [None, [VLenBytesCodec()], [VLenBytesCodec(), ZstdCodec()]]
-)
+@pytest.mark.parametrize("compressor", [None, ZstdCodec()])
 def test_vlen_bytes(
-    *, store: Store, as_object_array: bool, codecs: None | list[Codec]
+    store: Store, *, as_object_array: bool, compressor: Codec | None
 ) -> None:
     bstrings = [b"hello", b"world", b"this", b"is", b"a", b"test"]
     data = np.array(bstrings).reshape((2, 3))
     assert data.dtype == "|S5"
 
     sp = StorePath(store, path="string")
-    a = Array.create(
+    a = zarr.create_array(
         sp,
         shape=data.shape,
-        chunk_shape=data.shape,
+        chunks=data.shape,
         dtype=data.dtype,
         fill_value=b"",
-        codecs=codecs,
+        compressors=compressor,
     )
     assert isinstance(a.metadata, ArrayV3Metadata)  # needed for mypy
 
@@ -97,7 +93,7 @@ def test_vlen_bytes(
     assert a.dtype == "O"
 
     # test round trip
-    b = Array.open(sp)
+    b = zarr.open(sp)
     assert isinstance(b.metadata, ArrayV3Metadata)  # needed for mypy
     assert np.array_equal(data, b[:, :])
     assert b.metadata.data_type == DataType.bytes


### PR DESCRIPTION
See: https://numpy.org/devdocs/reference/generated/numpy.dtype.kind.html This allows us to support `numpy.dtypes.StringDType` (or at least properly fall back to python)

I also un-skipped all the `vlen` tests.