### PR TITLE
(fix): blosc v2 `typesize` in config

### DIFF
--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -75,7 +75,7 @@ def codecs_to_dict(codecs: Iterable[Codec]) -> Generator[dict[str, Any], None, N
                 compressor_json = codec_dict.get("compressor").get_config()
                 # https://github.com/zarr-developers/numcodecs/pull/713 means
                 # typesize is always present, but it's not expected
-                # to be on v2 blosc codecs.
+                # to be on v2 blosc codecs by zarrs.
                 if compressor_json["id"] == "blosc":
                     compressor_json.pop("typesize", None)
                 compressor = json.dumps(compressor_json)

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -72,7 +72,13 @@ def codecs_to_dict(codecs: Iterable[Codec]) -> Generator[dict[str, Any], None, N
             else:
                 filters = None
             if codec_dict.get("compressor", None) is not None:
-                compressor = json.dumps(codec_dict.get("compressor").get_config())
+                compressor_json = codec_dict.get("compressor").get_config()
+                # https://github.com/zarr-developers/numcodecs/pull/713 means
+                # typesize is always present, but it's not expected
+                # to be on v2 blosc codecs.
+                if compressor_json["id"] == "blosc":
+                    compressor_json.pop("typesize", None)
+                compressor = json.dumps(compressor_json)
             else:
                 compressor = None
             codecs_v3 = codec_metadata_v2_to_v3(filters, compressor)


### PR DESCRIPTION
Handling the new `typesize` in the declaration of the object: https://github.com/zarr-developers/numcodecs/pull/713.  I don't think we need to worry about the object being declared with `typesize` in v2 (and for now, `zarrs` doesn't seem to support it anyway)