### PR TITLE
chore(deps): bump `zarrs_metadata` to 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ pyo3-stub-gen = "0.7.0"
 opendal = { version = "0.51.0", features = ["services-http"] }
 tokio = { version = "1.41.1", features = ["rt-multi-thread"] }
 zarrs_opendal = "0.5.0"
-zarrs_metadata = "0.3.3" # require recent zarr-python compatibility fixes (remove with zarrs 0.20)
+zarrs_metadata = "0.3.7" # require recent zarr-python compatibility fixes (remove with zarrs 0.20)
 itertools = "0.9.0"
 
 [profile.release]

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -73,11 +73,6 @@ def codecs_to_dict(codecs: Iterable[Codec]) -> Generator[dict[str, Any], None, N
                 filters = None
             if codec_dict.get("compressor", None) is not None:
                 compressor_json = codec_dict.get("compressor").get_config()
-                # https://github.com/zarr-developers/numcodecs/pull/713 means
-                # typesize is always present, but it's not expected
-                # to be on v2 blosc codecs by zarrs.
-                if compressor_json["id"] == "blosc":
-                    compressor_json.pop("typesize", None)
                 compressor = json.dumps(compressor_json)
             else:
                 compressor = None


### PR DESCRIPTION
The `blosc` typesize workaround is no longer needed