### PR TITLE
feat: subchunk write order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,12 @@ env:
 
 jobs:
   build_and_test:
-    name: build and test
+    name: build and test (zarr ${{ matrix.zarr_version }})
     strategy:
       fail-fast: false
       matrix:
         rust_toolchain: ["stable"]  # "nightly"
+        zarr_version: ["released", "main"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -52,6 +53,12 @@ jobs:
       - name: Install python deps + Build
         run: |
           uv pip install --system -e . --group dev --verbose
+
+      - name: Install zarr-python from main
+        if: matrix.zarr_version == 'main'
+        run: |
+          uv pip install --system --reinstall-package zarr \
+            "zarr @ git+https://github.com/zarr-developers/zarr-python.git@main"
 
       - name: Python Tests
         run: pytest -n auto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.27.1", features = ["abi3-py311"] }
-zarrs = { version = "0.23.6", features = ["async", "zlib", "pcodec", "bz2"] }
+zarrs = { version = "0.23.7", features = ["async", "zlib", "pcodec", "bz2"] }
 rayon_iter_concurrent_limit = "0.2.0"
 rayon = "1.10.0"
 # fix for https://stackoverflow.com/questions/76593417/package-openssl-was-not-found-in-the-pkg-config-search-path

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ The `ZarrsCodecPipeline` specific options are:
   - Defaults to `False`.
 - `codec_pipeline.strict`: raise exceptions for unsupported operations instead of falling back to the default codec pipeline of `zarr-python`.
   - Defaults to `False`.
+- `codec_pipeline.subchunk_write_order`: Tells `zarrs` in what order to write subchunks within a shard. One of "C" or "random."
+  - Defaults to `random`.
 
 For example:
 ```python
@@ -63,7 +65,8 @@ zarr.config.set({
         "chunk_concurrent_maximum": None,
         "chunk_concurrent_minimum": 4,
         "direct_io": False,
-        "strict": False
+        "strict": False,
+        "subchunk_write_order": "C"
     }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ zarr.config.set({
         "chunk_concurrent_minimum": 4,
         "direct_io": False,
         "strict": False,
-        "subchunk_write_order": "C"
-    }
+        "subchunk_write_order": "C",
+},
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The `ZarrsCodecPipeline` specific options are:
   - Defaults to `False`.
 - `codec_pipeline.strict`: raise exceptions for unsupported operations instead of falling back to the default codec pipeline of `zarr-python`.
   - Defaults to `False`.
-- `codec_pipeline.subchunk_write_order`: Tells `zarrs` in what order to write subchunks within a shard. One of "C" or "random."
+- `codec_pipeline.subchunk_write_order`: Tells `zarrs` in what order to write subchunks within a shard. One of "C" or "random." "C" ordering is `numpy`-speak for [row-major](https://en.wikipedia.org/wiki/Row-_and_column-major_order). "Random" is a bit of a misnomer and implies no ordering in reality, instead being unordered as a result of `rayon`'s lack of ordering guarantee.
   - Defaults to `random`.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ zarr.config.set({
         "direct_io": False,
         "strict": False,
         "subchunk_write_order": "C",
-},
+    },
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ The `ZarrsCodecPipeline` specific options are:
   - Defaults to `False`.
 - `codec_pipeline.strict`: raise exceptions for unsupported operations instead of falling back to the default codec pipeline of `zarr-python`.
   - Defaults to `False`.
-- `codec_pipeline.subchunk_write_order`: Tells `zarrs` in what order to write subchunks within a shard. One of "C" or "random." "C" ordering is `numpy`-speak for [row-major](https://en.wikipedia.org/wiki/Row-_and_column-major_order). "Random" is a bit of a misnomer and implies no ordering in reality, instead being unordered as a result of `rayon`'s lack of ordering guarantee.
-  - Defaults to `random`.
+
+The subchunk write order within a shard is derived from each `ShardingCodec`'s `subchunk_write_order` (`zarr-python` >= 3.2.2). Nested shards are handled per level: the order is read from the sharding codec at each nesting depth. `zarrs` falls back to `unordered` for `morton`/`colexicographic` but can handle `lexicographic` and `unordered` explicitly.
 
 For example:
 ```python
@@ -66,7 +66,6 @@ zarr.config.set({
         "chunk_concurrent_minimum": 4,
         "direct_io": False,
         "strict": False,
-        "subchunk_write_order": "C",
     },
 })
 ```

--- a/python/zarrs/_internal.pyi
+++ b/python/zarrs/_internal.pyi
@@ -30,6 +30,7 @@ class CodecPipelineImpl:
         chunk_concurrent_maximum: builtins.int | None = None,
         num_threads: builtins.int | None = None,
         direct_io: builtins.bool = False,
+        subchunk_write_order: builtins.str = "random",
     ) -> CodecPipelineImpl: ...
     def retrieve_chunks_and_apply_index(
         self,

--- a/python/zarrs/_internal.pyi
+++ b/python/zarrs/_internal.pyi
@@ -30,7 +30,7 @@ class CodecPipelineImpl:
         chunk_concurrent_maximum: builtins.int | None = None,
         num_threads: builtins.int | None = None,
         direct_io: builtins.bool = False,
-        subchunk_write_order: builtins.str = "random",
+        subchunk_write_order: typing.Literal["C", "random"] = "random",
     ) -> CodecPipelineImpl: ...
     def retrieve_chunks_and_apply_index(
         self,

--- a/python/zarrs/_internal.pyi
+++ b/python/zarrs/_internal.pyi
@@ -30,7 +30,9 @@ class CodecPipelineImpl:
         chunk_concurrent_maximum: builtins.int | None = None,
         num_threads: builtins.int | None = None,
         direct_io: builtins.bool = False,
-        subchunk_write_order: typing.Literal["C", "random"] = "random",
+        subchunk_write_order: builtins.list[
+            typing.Literal["morton", "unordered", "lexicographic", "colexicographic"]
+        ] = [],
     ) -> CodecPipelineImpl: ...
     def retrieve_chunks_and_apply_index(
         self,

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -62,6 +62,9 @@ def get_codec_pipeline_impl(
             ),
             num_threads=config.get("threading.max_workers", None),
             direct_io=config.get("codec_pipeline.direct_io", False),
+            subchunk_write_order=config.get(
+                "codec_pipeline.subchunk_write_order", "random"
+            ),
         )
     except TypeError as e:
         if strict:

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Literal, TypedDict
 from warnings import warn
 
 import numpy as np
 from zarr.abc.codec import Codec, CodecPipeline
+from zarr.codecs import ShardingCodec
 from zarr.codecs._v2 import V2Codec
 from zarr.core import BatchedCodecPipeline
 from zarr.core.config import config
@@ -31,6 +32,8 @@ from .utils import (
     UnsupportedVIndexingError,
     make_chunk_info_for_rust_with_indices,
 )
+
+SubchunkWriteOrder = Literal["morton", "unordered", "lexicographic", "colexicographic"]
 
 
 class UnsupportedDataTypeError(Exception):
@@ -62,9 +65,7 @@ def get_codec_pipeline_impl(
             ),
             num_threads=config.get("threading.max_workers", None),
             direct_io=config.get("codec_pipeline.direct_io", False),
-            subchunk_write_order=config.get(
-                "codec_pipeline.subchunk_write_order", "random"
-            ),
+            subchunk_write_order=_subchunk_write_orders(metadata),
         )
     except TypeError as e:
         if strict:
@@ -90,6 +91,30 @@ def get_codec_pipeline_fallback(
 class ZarrsCodecPipelineState(TypedDict):
     codec_metadata_json: str
     codecs: tuple[Codec, ...]
+
+
+def _subchunk_write_orders(
+    metadata: ArrayMetadata,
+) -> list[SubchunkWriteOrder]:
+    """Subchunk write order can be nested inside the sharding codec - return that order here.
+
+    Parameters
+    ----------
+    metadata
+        The array metadata containing the potentially nested shards.
+
+    Returns
+    -------
+        A list of subchunk write orders
+    """
+    orders: list[SubchunkWriteOrder] = []
+    codecs: Iterable[Codec] = array_metadata_to_codecs(metadata)
+    while (
+        sharding := next((c for c in codecs if isinstance(c, ShardingCodec)), None)
+    ) is not None:
+        orders.append(getattr(sharding, "subchunk_write_order", "morton"))
+        codecs = sharding.codecs
+    return orders
 
 
 def array_metadata_to_codecs(metadata: ArrayMetadata) -> list[Codec]:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,12 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_iter_concurrent_limit::iter_concurrent_limit;
 use unsafe_cell_slice::UnsafeCellSlice;
 use utils::is_whole_chunk;
+use zarrs::array::codec::{ShardingCodecOptions, SubchunkWriteOrder};
 use zarrs::array::{
     ArrayBytes, ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, ArrayMetadata,
-    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecChain, CodecOptions, DataType,
-    FillValue, StoragePartialDecoder, copy_fill_value_into, update_array_bytes,
+    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecChain, CodecOptions,
+    CodecSpecificOptions, DataType, FillValue, StoragePartialDecoder, copy_fill_value_into,
+    update_array_bytes,
 };
 use zarrs::config::global_config;
 use zarrs::convert::array_metadata_v2_to_v3;
@@ -38,7 +40,7 @@ mod utils;
 
 use crate::concurrency::ChunkConcurrentLimitAndCodecOptions;
 use crate::store::StoreConfig;
-use crate::utils::{PyCodecErrExt, PyErrExt as _};
+use crate::utils::{PyCodecErrExt, PyErrExt as _, SubchunkWriteOrderWrapper};
 
 // TODO: Use a OnceLock for store with get_or_try_init when stabilised?
 #[gen_stub_pyclass]
@@ -218,6 +220,7 @@ impl CodecPipelineImpl {
         chunk_concurrent_maximum=None,
         num_threads=None,
         direct_io=false,
+        subchunk_write_order=SubchunkWriteOrderWrapper(SubchunkWriteOrder::Random),
     ))]
     #[new]
     fn new(
@@ -228,6 +231,7 @@ impl CodecPipelineImpl {
         chunk_concurrent_maximum: Option<usize>,
         num_threads: Option<usize>,
         direct_io: bool,
+        subchunk_write_order: SubchunkWriteOrderWrapper,
     ) -> PyResult<Self> {
         store_config.direct_io(direct_io);
         let metadata = serde_json::from_str(array_metadata).map_py_err::<PyTypeError>()?;
@@ -237,8 +241,16 @@ impl CodecPipelineImpl {
             }
             ArrayMetadata::V3(v3) => Cow::Borrowed(v3),
         };
-        let codec_chain =
-            Arc::new(CodecChain::from_metadata(&metadata_v3.codecs).map_py_err::<PyTypeError>()?);
+        let codec_chain = Arc::new(
+            CodecChain::from_metadata(&metadata_v3.codecs)
+                .map_py_err::<PyTypeError>()?
+                .with_codec_specific_options(
+                    &CodecSpecificOptions::default().with_option(
+                        ShardingCodecOptions::default()
+                            .with_subchunk_write_order(subchunk_write_order.0),
+                    ),
+                ),
+        );
         let codec_options = CodecOptions::default().with_validate_checksums(validate_checksums);
 
         let chunk_concurrent_minimum =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ impl CodecPipelineImpl {
 #[gen_stub_pymethods]
 #[pymethods]
 impl CodecPipelineImpl {
+    #[allow(clippy::too_many_arguments)] // python functions can have defaults
     #[pyo3(signature = (
         array_metadata,
         store_config,
@@ -266,17 +267,15 @@ impl CodecPipelineImpl {
             DataType::from_metadata(&metadata_v3.data_type).map_py_err::<PyTypeError>()?;
         let fill_value = data_type
             .fill_value(&metadata_v3.fill_value, ZarrVersion::V3)
-            .or_else(|_| {
-                Err(match &metadata {
-                    ArrayMetadata::V2(metadata) => format!(
-                        "incompatible fill value metadata: dtype={}, fill_value={}",
-                        metadata.dtype, metadata.fill_value
-                    ),
-                    ArrayMetadata::V3(metadata) => format!(
-                        "incompatible fill value metadata: data_type={}, fill_value={}",
-                        metadata.data_type, metadata.fill_value
-                    ),
-                })
+            .map_err(|_| match &metadata {
+                ArrayMetadata::V2(metadata) => format!(
+                    "incompatible fill value metadata: dtype={}, fill_value={}",
+                    metadata.dtype, metadata.fill_value
+                ),
+                ArrayMetadata::V3(metadata) => format!(
+                    "incompatible fill value metadata: data_type={}, fill_value={}",
+                    metadata.data_type, metadata.fill_value
+                ),
             })
             .map_py_err::<PyTypeError>()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,15 +18,15 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon_iter_concurrent_limit::iter_concurrent_limit;
 use unsafe_cell_slice::UnsafeCellSlice;
 use utils::is_whole_chunk;
-use zarrs::array::codec::{ShardingCodecOptions, SubchunkWriteOrder};
+use zarrs::array::codec::{ShardingCodec, ShardingCodecConfiguration, SubchunkWriteOrder};
 use zarrs::array::{
     ArrayBytes, ArrayBytesDecodeIntoTarget, ArrayBytesFixedDisjointView, ArrayMetadata,
-    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecChain, CodecOptions,
-    CodecSpecificOptions, DataType, FillValue, StoragePartialDecoder, copy_fill_value_into,
-    update_array_bytes,
+    ArrayPartialDecoderTraits, ArrayToBytesCodecTraits, CodecChain, CodecOptions, DataType,
+    FillValue, StoragePartialDecoder, copy_fill_value_into, update_array_bytes,
 };
 use zarrs::config::global_config;
 use zarrs::convert::array_metadata_v2_to_v3;
+use zarrs::metadata::v3::MetadataV3;
 use zarrs::plugin::ZarrVersion;
 use zarrs::storage::{ReadableWritableListableStorage, StorageHandle, StoreKey};
 
@@ -41,6 +41,59 @@ mod utils;
 use crate::concurrency::ChunkConcurrentLimitAndCodecOptions;
 use crate::store::StoreConfig;
 use crate::utils::{PyCodecErrExt, PyErrExt as _, SubchunkWriteOrderWrapper};
+
+/// Build a codec chain from metadata, applying `orders[depth]` to the sharding
+/// codec at each nesting level (outermost = `orders[0]`). Sharding nests
+/// linearly (one array->bytes codec per chain), so the list is indexed by depth.
+/// Levels beyond the list, or an empty list, keep zarrs' default order.
+fn codec_chain_with_subchunk_write_orders(
+    codecs: &[MetadataV3],
+    orders: &[SubchunkWriteOrderWrapper],
+) -> PyResult<CodecChain> {
+    let base = CodecChain::from_metadata(codecs).map_py_err::<PyTypeError>()?;
+    let array_to_bytes = base.array_to_bytes_codec();
+    let array_to_bytes: Arc<dyn ArrayToBytesCodecTraits> =
+        if array_to_bytes.as_any().is::<ShardingCodec>() {
+            let ShardingCodecConfiguration::V1(config) = codecs
+                .iter()
+                .find_map(|m| m.to_configuration::<ShardingCodecConfiguration>().ok())
+                .ok_or_else(|| {
+                    PyErr::new::<PyTypeError, _>(
+                        "sharding codec present but its metadata was not found",
+                    )
+                })?
+            else {
+                return Err(PyErr::new::<PyTypeError, _>(
+                    "unsupported sharding codec configuration version",
+                ));
+            };
+            let order = orders
+                .first()
+                .map_or(SubchunkWriteOrder::Unordered, |o| o.0);
+            let inner = codec_chain_with_subchunk_write_orders(
+                &config.codecs,
+                orders.get(1..).unwrap_or_default(),
+            )?;
+            let index =
+                CodecChain::from_metadata(&config.index_codecs).map_py_err::<PyTypeError>()?;
+            Arc::new(
+                ShardingCodec::new(
+                    config.chunk_shape,
+                    Arc::new(inner),
+                    Arc::new(index),
+                    config.index_location,
+                )
+                .with_subchunk_write_order(order),
+            )
+        } else {
+            array_to_bytes.clone()
+        };
+    Ok(CodecChain::new(
+        base.array_to_array_codecs().to_vec(),
+        array_to_bytes,
+        base.bytes_to_bytes_codecs().to_vec(),
+    ))
+}
 
 // TODO: Use a OnceLock for store with get_or_try_init when stabilised?
 #[gen_stub_pyclass]
@@ -212,6 +265,7 @@ impl CodecPipelineImpl {
 #[pymethods]
 impl CodecPipelineImpl {
     #[allow(clippy::too_many_arguments)] // python functions can have defaults
+    #[allow(clippy::needless_pass_by_value)] // pyo3 extracts args by value
     #[pyo3(signature = (
         array_metadata,
         store_config,
@@ -221,7 +275,7 @@ impl CodecPipelineImpl {
         chunk_concurrent_maximum=None,
         num_threads=None,
         direct_io=false,
-        subchunk_write_order=SubchunkWriteOrderWrapper(SubchunkWriteOrder::Random),
+        subchunk_write_order=Vec::new(),
     ))]
     #[new]
     fn new(
@@ -232,7 +286,10 @@ impl CodecPipelineImpl {
         chunk_concurrent_maximum: Option<usize>,
         num_threads: Option<usize>,
         direct_io: bool,
-        subchunk_write_order: SubchunkWriteOrderWrapper,
+        // One order per sharding-codec nesting level, outermost first. Sharding
+        // nests linearly (a codec chain has exactly one array->bytes codec), so a
+        // flat depth-indexed list is enough — no tree needed.
+        subchunk_write_order: Vec<SubchunkWriteOrderWrapper>,
     ) -> PyResult<Self> {
         store_config.direct_io(direct_io);
         let metadata = serde_json::from_str(array_metadata).map_py_err::<PyTypeError>()?;
@@ -242,16 +299,10 @@ impl CodecPipelineImpl {
             }
             ArrayMetadata::V3(v3) => Cow::Borrowed(v3),
         };
-        let codec_chain = Arc::new(
-            CodecChain::from_metadata(&metadata_v3.codecs)
-                .map_py_err::<PyTypeError>()?
-                .with_codec_specific_options(
-                    &CodecSpecificOptions::default().with_option(
-                        ShardingCodecOptions::default()
-                            .with_subchunk_write_order(subchunk_write_order.0),
-                    ),
-                ),
-        );
+        let codec_chain = Arc::new(codec_chain_with_subchunk_write_orders(
+            &metadata_v3.codecs,
+            &subchunk_write_order,
+        )?);
         let codec_options = CodecOptions::default().with_validate_checksums(validate_checksums);
 
         let chunk_concurrent_minimum =

--- a/src/store.rs
+++ b/src/store.rs
@@ -72,7 +72,7 @@ impl<'py> FromPyObject<'_, 'py> for StoreConfig {
 }
 
 impl StoreConfig {
-    pub fn direct_io(&mut self, flag: bool) -> () {
+    pub fn direct_io(&mut self, flag: bool) {
         match self {
             StoreConfig::Filesystem(config) => config.direct_io(flag),
             StoreConfig::Http(_config) => (),

--- a/src/store/filesystem.rs
+++ b/src/store/filesystem.rs
@@ -22,7 +22,7 @@ impl FilesystemStoreConfig {
         }
     }
 
-    pub fn direct_io(&mut self, flag: bool) -> () {
+    pub fn direct_io(&mut self, flag: bool) {
         self.opts.direct_io(flag);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,8 +10,8 @@ use crate::CodecPipelineImpl;
 
 #[test]
 fn test_nparray_to_unsafe_cell_slice_empty() -> PyResult<()> {
-    pyo3::prepare_freethreaded_python();
-    Python::with_gil(|py| {
+    Python::initialize();
+    Python::attach(|py| {
         let arr: Bound<'_, PyUntypedArray> = PyModule::from_code(
             py,
             c_str!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,10 @@
 use std::fmt::Display;
 
-use pyo3::{PyErr, PyResult, PyTypeInfo};
-use zarrs::array::CodecError;
+use pyo3::{
+    Borrowed, Bound, FromPyObject, IntoPyObject, PyAny, PyErr, PyResult, PyTypeInfo, Python,
+    exceptions::PyValueError, types::PyString,
+};
+use zarrs::array::{CodecError, codec::SubchunkWriteOrder};
 
 use crate::ChunkItem;
 
@@ -40,4 +43,41 @@ impl<T> PyCodecErrExt<T> for Result<T, CodecError> {
 pub fn is_whole_chunk(item: &ChunkItem) -> bool {
     item.chunk_subset.start().iter().all(|&o| o == 0)
         && item.chunk_subset.shape() == bytemuck::must_cast_slice::<_, u64>(&item.shape)
+}
+
+#[derive(Debug, Clone)]
+pub struct SubchunkWriteOrderWrapper(pub SubchunkWriteOrder);
+
+impl<'py> IntoPyObject<'py> for SubchunkWriteOrderWrapper {
+    type Target = PyString;
+    type Output = Bound<'py, PyString>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self.0 {
+            SubchunkWriteOrder::C => Ok("C".into_pyobject(py)?),
+            SubchunkWriteOrder::Random => Ok("random".into_pyobject(py)?),
+            _ => unreachable!("Unrecognized subchunk write order, only `C` and `random` allowed."),
+        }
+    }
+}
+
+impl<'py> FromPyObject<'_, 'py> for SubchunkWriteOrderWrapper {
+    type Error = PyErr;
+
+    fn extract(option: Borrowed<'_, 'py, PyAny>) -> PyResult<SubchunkWriteOrderWrapper> {
+        match option.extract::<&str>()? {
+            "C" => Ok(SubchunkWriteOrderWrapper(SubchunkWriteOrder::C)),
+            "random" => Ok(SubchunkWriteOrderWrapper(SubchunkWriteOrder::Random)),
+            _ => Err(PyValueError::new_err(
+                "Unrecognized subchunk write order, only `C` and `random` allowed.",
+            )),
+        }
+    }
+}
+
+impl pyo3_stub_gen::PyStubType for SubchunkWriteOrderWrapper {
+    fn type_output() -> pyo3_stub_gen::TypeInfo {
+        pyo3_stub_gen::TypeInfo::builtin("str")
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -45,7 +45,7 @@ pub fn is_whole_chunk(item: &ChunkItem) -> bool {
         && item.chunk_subset.shape() == bytemuck::must_cast_slice::<_, u64>(&item.shape)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct SubchunkWriteOrderWrapper(pub SubchunkWriteOrder);
 
 impl<'py> IntoPyObject<'py> for SubchunkWriteOrderWrapper {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,7 +57,9 @@ impl<'py> IntoPyObject<'py> for SubchunkWriteOrderWrapper {
         match self.0 {
             SubchunkWriteOrder::C => Ok("C".into_pyobject(py)?),
             SubchunkWriteOrder::Random => Ok("random".into_pyobject(py)?),
-            _ => unreachable!("Unrecognized subchunk write order, only `C` and `random` allowed."),
+            _ => Err(PyValueError::new_err(
+                "Unrecognized subchunk write order for converting to python object, only `C` and `random` allowed.",
+            )),
         }
     }
 }
@@ -70,7 +72,7 @@ impl<'py> FromPyObject<'_, 'py> for SubchunkWriteOrderWrapper {
             "C" => Ok(SubchunkWriteOrderWrapper(SubchunkWriteOrder::C)),
             "random" => Ok(SubchunkWriteOrderWrapper(SubchunkWriteOrder::Random)),
             _ => Err(PyValueError::new_err(
-                "Unrecognized subchunk write order, only `C` and `random` allowed.",
+                "Unrecognized subchunk write order while extracting to rust, only `C` and `random` allowed.",
             )),
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,6 +80,6 @@ impl<'py> FromPyObject<'_, 'py> for SubchunkWriteOrderWrapper {
 
 impl pyo3_stub_gen::PyStubType for SubchunkWriteOrderWrapper {
     fn type_output() -> pyo3_stub_gen::TypeInfo {
-        pyo3_stub_gen::TypeInfo::builtin("str")
+        pyo3_stub_gen::TypeInfo::with_module("typing.Literal['C', 'random']", "typing".into())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,6 +48,11 @@ pub fn is_whole_chunk(item: &ChunkItem) -> bool {
 #[derive(Debug, Clone, Copy)]
 pub struct SubchunkWriteOrderWrapper(pub SubchunkWriteOrder);
 
+// zarr-python's sharding codec exposes `subchunk_write_order` as one of
+// morton / unordered / lexicographic / colexicographic. zarrs can only write
+// C (== lexicographic) and Unordered, so the orders it can't reproduce fall
+// back to Unordered — data is correct, only the physical byte layout differs.
+// ponytail: map morton/colexicographic -> Unordered until zarrs can write them.
 impl<'py> IntoPyObject<'py> for SubchunkWriteOrderWrapper {
     type Target = PyString;
     type Output = Bound<'py, PyString>;
@@ -55,10 +60,12 @@ impl<'py> IntoPyObject<'py> for SubchunkWriteOrderWrapper {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
-            SubchunkWriteOrder::C => Ok("C".into_pyobject(py)?),
-            SubchunkWriteOrder::Random => Ok("random".into_pyobject(py)?),
+            SubchunkWriteOrder::C => Ok("lexicographic".into_pyobject(py)?),
+            SubchunkWriteOrder::Unordered | SubchunkWriteOrder::Random => {
+                Ok("unordered".into_pyobject(py)?)
+            }
             _ => Err(PyValueError::new_err(
-                "Unrecognized subchunk write order for converting to python object, only `C` and `random` allowed.",
+                "Unrecognized subchunk write order for converting to python object.",
             )),
         }
     }
@@ -68,18 +75,24 @@ impl<'py> FromPyObject<'_, 'py> for SubchunkWriteOrderWrapper {
     type Error = PyErr;
 
     fn extract(option: Borrowed<'_, 'py, PyAny>) -> PyResult<SubchunkWriteOrderWrapper> {
-        match option.extract::<&str>()? {
-            "C" => Ok(SubchunkWriteOrderWrapper(SubchunkWriteOrder::C)),
-            "random" => Ok(SubchunkWriteOrderWrapper(SubchunkWriteOrder::Random)),
-            _ => Err(PyValueError::new_err(
-                "Unrecognized subchunk write order while extracting to rust, only `C` and `random` allowed.",
-            )),
-        }
+        let order = match option.extract::<&str>()? {
+            "lexicographic" => SubchunkWriteOrder::C,
+            "unordered" | "morton" | "colexicographic" => SubchunkWriteOrder::Unordered,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "Unrecognized subchunk write order {other:?}, only `morton`, `unordered`, `lexicographic` and `colexicographic` allowed.",
+                )));
+            }
+        };
+        Ok(SubchunkWriteOrderWrapper(order))
     }
 }
 
 impl pyo3_stub_gen::PyStubType for SubchunkWriteOrderWrapper {
     fn type_output() -> pyo3_stub_gen::TypeInfo {
-        pyo3_stub_gen::TypeInfo::with_module("typing.Literal['C', 'random']", "typing".into())
+        pyo3_stub_gen::TypeInfo::with_module(
+            "typing.Literal['morton', 'unordered', 'lexicographic', 'colexicographic']",
+            "typing".into(),
+        )
     }
 }

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,8 +1,9 @@
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
 import pytest
+import zarr
 from zarr import Array, AsyncArray
 from zarr.abc.store import Store
 from zarr.codecs import (
@@ -367,3 +368,36 @@ async def test_sharding_with_empty_inner_chunk(
     print("read data")
     data_read = await a.getitem(...)
     assert np.array_equal(data_read, data)
+
+
+@pytest.mark.parametrize(
+    "index_location", [ShardingCodecIndexLocation.start, ShardingCodecIndexLocation.end]
+)
+@pytest.mark.parametrize("subchunk_write_order", ["C", "random"])
+async def test_sharding_subchunk_write_order(
+    store: Store,
+    index_location: ShardingCodecIndexLocation,
+    subchunk_write_order: Literal["C", "random"],
+) -> None:
+    with zarr.config.set({"codec_pipeline.subchunk_write_order": subchunk_write_order}):
+        path = f"sharding_with_empty_inner_chunk_{index_location}"
+        spath = StorePath(store, path)
+        codec = ShardingCodec(chunk_shape=(2, 2), index_location=index_location)
+        a = await AsyncArray.create(
+            spath,
+            shape=(16, 16),
+            chunk_shape=(16, 16),
+            dtype="uint32",
+            fill_value=0,
+            codecs=[codec],
+        )
+        await a.setitem(..., np.arange(16 * 16).reshape((16, 16)))
+        index = await codec._load_shard_index(a.store_path / "/c/0/0", (8, 8))
+        index_offsets = index.offsets_and_lengths[index.get_full_chunk_map()].ravel()[
+            ::2
+        ]
+        assert len(index_offsets) == 64  # 8 * 8
+        if subchunk_write_order == "C":
+            np.testing.assert_equal(np.sort(index_offsets), index_offsets)
+        else:
+            assert not np.array_equal(np.sort(index_offsets), index_offsets)

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,11 +1,13 @@
+import inspect
 import warnings
-from typing import Any, Literal
+from importlib.metadata import version
+from typing import Any, get_args
 
 import numpy as np
 import numpy.typing as npt
 import pytest
-import zarr
-from zarr import AsyncArray, create_array
+from packaging.version import Version
+from zarr import config, create_array
 from zarr.abc.store import Store
 from zarr.api.asynchronous import create_array as create_async_array
 from zarr.codecs import (
@@ -17,7 +19,9 @@ from zarr.codecs import (
 from zarr.core.array import ShardsConfigParam
 from zarr.core.buffer import default_buffer_prototype
 from zarr.errors import ZarrUserWarning
-from zarr.storage import StorePath
+from zarr.storage import LocalStore, StorePath
+
+from zarrs.pipeline import SubchunkWriteOrder
 
 from .conftest import ArrayRequest
 from .test_codecs import _AsyncArrayProxy, order_from_dim
@@ -324,34 +328,67 @@ async def test_sharding_with_empty_inner_chunk(
     assert np.array_equal(data_read, data)
 
 
-@pytest.mark.parametrize(
-    "index_location", [ShardingCodecIndexLocation.start, ShardingCodecIndexLocation.end]
+_SHARDING_HAS_WRITE_ORDER = (
+    "subchunk_write_order" in inspect.signature(ShardingCodec).parameters
 )
-@pytest.mark.parametrize("subchunk_write_order", ["C", "random"])
-async def test_sharding_subchunk_write_order(
-    store: Store,
-    index_location: ShardingCodecIndexLocation,
-    subchunk_write_order: Literal["C", "random"],
+
+# `subchunk_write_order` on the sharding codec is a zarr-python >=3.2.2 feature.
+requires_write_order = pytest.mark.skipif(
+    Version(version("zarr")) < Version("3.2.2dev0"),
+    reason="zarr-python ShardingCodec has no subchunk_write_order",
+)
+
+
+@requires_write_order
+@pytest.mark.parametrize("nested", [False, True], ids=["flat", "nested"])
+@pytest.mark.parametrize("subchunk_write_order", list(get_args(SubchunkWriteOrder)))
+def test_subchunk_write_order_matches_zarr_python(
+    tmp_path, *, subchunk_write_order: SubchunkWriteOrder, nested: bool
 ) -> None:
-    with zarr.config.set({"codec_pipeline.subchunk_write_order": subchunk_write_order}):
-        path = f"sharding_with_empty_inner_chunk_{index_location}"
-        spath = StorePath(store, path)
-        codec = ShardingCodec(chunk_shape=(2, 2), index_location=index_location)
-        a = await AsyncArray.create(
-            spath,
-            shape=(16, 16),
-            chunk_shape=(16, 16),
-            dtype="uint32",
-            fill_value=0,
-            codecs=[codec],
+    data = np.arange(1, 32 * 32 + 1, dtype="uint32").reshape((32, 32))
+    ground_truth_subchunk_write_order = (
+        "unordered"
+        if subchunk_write_order in {"colexicographic", "unordered", "morton"}
+        else "lexicographic"
+    )
+    if nested:
+        zarrs_codec = ShardingCodec(
+            chunk_shape=(8, 8),
+            subchunk_write_order=subchunk_write_order,
+            codecs=[
+                ShardingCodec(chunk_shape=(2, 2), subchunk_write_order="lexicographic")
+            ],
         )
-        await a.setitem(..., np.arange(16 * 16).reshape((16, 16)))
-        index = await codec._load_shard_index(a.store_path / "/c/0/0", (8, 8))
-        index_offsets = index.offsets_and_lengths[index.get_full_chunk_map()].ravel()[
-            ::2
-        ]
-        assert len(index_offsets) == 64  # 8 * 8
-        if subchunk_write_order == "C":
-            np.testing.assert_equal(np.sort(index_offsets), index_offsets)
-        else:
-            assert not np.array_equal(np.sort(index_offsets), index_offsets)
+        zarr_codec = ShardingCodec(
+            chunk_shape=(8, 8),
+            subchunk_write_order=ground_truth_subchunk_write_order,
+            codecs=[
+                ShardingCodec(chunk_shape=(2, 2), subchunk_write_order="lexicographic")
+            ],
+        )
+    else:
+        zarrs_codec = ShardingCodec(
+            chunk_shape=(8, 8), subchunk_write_order="lexicographic"
+        )
+        zarr_codec = ShardingCodec(
+            chunk_shape=(8, 8), subchunk_write_order=ground_truth_subchunk_write_order
+        )
+
+    def write(pipeline: str) -> bytes:
+        sub = tmp_path / pipeline.rsplit(".", 1)[-1]
+        with config.set({"codec_pipeline.path": pipeline}):
+            a = create_array(
+                StorePath(LocalStore(sub)),
+                shape=(32, 32),
+                chunks=(32, 32),
+                dtype="uint32",
+                fill_value=0,
+                serializer=zarrs_codec if "zarrs" in pipeline else zarr_codec,
+                compressors=None,
+            )
+            a[:, :] = data
+        return (sub / "c" / "0" / "0").read_bytes()
+
+    zarrs_bytes = write("zarrs.ZarrsCodecPipeline")
+    zarr_bytes = write("zarr.core.codec_pipeline.BatchedCodecPipeline")
+    assert zarrs_bytes == zarr_bytes


### PR DESCRIPTION
1. I could not find a clean way to do `Literal` -> `Enum` in PyO3 despite extensive googling
2. Maybe @d-v-b we standardize where this option goes since it applies to everyone? Happy to contribute this upstream to `zarr-python` (including `C` + `random` write order)
3. Major release after this?