### PR TITLE
fix: array creation in tests

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,17 +1,14 @@
 use pyo3::ffi::c_str;
 
 use numpy::PyUntypedArray;
-use pyo3::{
-    Bound, PyResult, Python,
-    types::{PyAnyMethods, PyModule},
-};
+use pyo3::prelude::*;
 
 use crate::CodecPipelineImpl;
 
 #[test]
 fn test_nparray_to_unsafe_cell_slice_empty() -> PyResult<()> {
-    pyo3::prepare_freethreaded_python();
-    Python::with_gil(|py| {
+    Python::initialize();
+    Python::attach(|py| {
         let arr: Bound<'_, PyUntypedArray> = PyModule::from_code(
             py,
             c_str!(

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -77,8 +77,8 @@ async def test_order(
         a = await create_async_array(
             spath,
             shape=data.shape,
-            chunks=(32, 8),
-            shards=(16, 8) if with_sharding else None,
+            chunks=(16, 8),
+            shards=(32, 8) if with_sharding else None,
             dtype=data.dtype,
             fill_value=0,
             chunk_key_encoding=ChunkKeyEncodingParams(name="v2", separator="."),
@@ -124,8 +124,8 @@ def test_order_implicit(
         a = create_array(
             spath,
             shape=data.shape,
-            chunks=(16, 16),
-            shards=(8, 8) if with_sharding else None,
+            chunks=(8, 8),
+            shards=(16, 16) if with_sharding else None,
             dtype=data.dtype,
             fill_value=0,
         )
@@ -176,25 +176,28 @@ async def test_delete_empty_chunks(store: Store) -> None:
     assert await store.get(f"{path}/c0/0", prototype=default_buffer_prototype()) is None
 
 
-def test_invalid_metadata(store: Store) -> None:
-    # LD: Disabled for `zarrs`. Including endianness for a single-byte data type is not invalid.
-    # spath2 = StorePath(store, "invalid_endian")
-    # with pytest.raises(TypeError):
-    #     create_array(
-    #         spath2,
-    #         shape=(16, 16),
-    #         chunks=(16, 16),
-    #         dtype=np.dtype("uint8"),
-    #         fill_value=0,
-    #         filters=[
-    #             TransposeCodec(order=order_from_dim("F", 2)),
-    #         ],
-    #         serializer=BytesCodec(endian="big"),
-    #     )
-    spath3 = StorePath(store, "invalid_order")
+# def test_invalid_metadata_endianness(store: Store) -> None:
+#     # LD: Disabled for `zarrs`. Including endianness for a single-byte data type is not invalid.
+#     spath2 = StorePath(store, "invalid_endian")
+#     with pytest.raises(TypeError):
+#         create_array(
+#             spath2,
+#             shape=(16, 16),
+#             chunks=(16, 16),
+#             dtype=np.dtype("uint8"),
+#             fill_value=0,
+#             filters=[
+#                 TransposeCodec(order=order_from_dim("F", 2)),
+#             ],
+#             serializer=BytesCodec(endian="big"),
+#         )
+
+
+def test_invalid_metadata_order(store: Store) -> None:
+    spath = StorePath(store, "invalid_order")
     with pytest.raises(TypeError):
         create_array(
-            spath3,
+            spath,
             shape=(16, 16),
             chunks=(16, 16),
             dtype=np.dtype("uint8"),
@@ -203,55 +206,48 @@ def test_invalid_metadata(store: Store) -> None:
                 TransposeCodec(order="F"),  # type: ignore[arg-type]
             ],
         )
-    spath4 = StorePath(store, "invalid_missing_bytes_codec")
-    with pytest.raises(ValueError, match=r".*[Cc]odec.*required"):
+
+
+def test_invalid_metadata_chunk_shape(store: Store) -> None:
+    spath = StorePath(store, "invalid_inner_chunk_shape")
+    with pytest.raises(ValueError, match=r"chunk.*number of dimensions"):
         create_array(
-            spath4,
-            shape=(16, 16),
-            chunks=(16, 16),
-            dtype=np.dtype("uint8"),
-            fill_value=0,
-            filters=[
-                TransposeCodec(order=order_from_dim("F", 2)),
-            ],
-        )
-    spath5 = StorePath(store, "invalid_inner_chunk_shape")
-    with pytest.raises(
-        ValueError, match=r".*shard.*chunk_shape.*array.*shape.*need.*same.*dimensions"
-    ):
-        create_array(
-            spath5,
-            shape=(16, 16),
-            chunks=(16, 16),
-            shards=(8,),
+            spath,
+            shape=(8, 8),
+            chunks=(8, 8),
+            shards=(16,),
             dtype=np.dtype("uint8"),
             fill_value=0,
         )
-    spath6 = StorePath(store, "invalid_inner_chunk_shape")
-    with pytest.raises(
-        ValueError, match=r".*array.*chunk_shape.*divisible.*shard.*chunk_shape"
-    ):
+
+
+def test_invalid_metadata_inner_chunk_shape(store: Store) -> None:
+    spath = StorePath(store, "invalid_inner_chunk_shape")
+    with pytest.raises(ValueError, match=r"inner chunk size"):
         create_array(
-            spath6,
-            shape=(16, 16),
-            chunks=(16, 16),
-            shards=(8, 7),
+            spath,
+            shape=(8, 8),
+            chunks=(8, 8),
+            shards=(16, 15),
             dtype=np.dtype("uint8"),
             fill_value=0,
         )
-    # LD: Disabled for `zarrs`. Such checks do not exist.
-    #     Also this is not invalid metadata, should be a separate test.
-    # spath7 = StorePath(store, "warning_inefficient_codecs")
-    # with pytest.warns(UserWarning):
-    #     create_array(
-    #         spath7,
-    #         shape=(16, 16),
-    #         chunks=(16, 16),
-    #         shards=(8, 8),
-    #         dtype=np.dtype("uint8"),
-    #         fill_value=0,
-    #         compressors=[GzipCodec()],
-    #     )
+
+
+# def test_invalid_metadata_order(store: Store) -> None:
+#     # LD: Disabled for `zarrs`. Such checks do not exist.
+#     # Also this is not invalid metadata, should be a separate test.
+#     spath7 = StorePath(store, "warning_inefficient_codecs")
+#     with pytest.warns(UserWarning):
+#         create_array(
+#             spath7,
+#             shape=(8, 8),
+#             chunks=(8, 8),
+#             shards=(16, 16),
+#             dtype=np.dtype("uint8"),
+#             fill_value=0,
+#             compressors=[GzipCodec()],
+#         )
 
 
 async def test_resize(store: Store) -> None:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -189,6 +189,7 @@ def test_invalid_metadata(store: Store) -> None:
     #         filters=[
     #             TransposeCodec(order=order_from_dim("F", 2)),
     #         ],
+    #         serializer=BytesCodec(endian="big"),
     #     )
     spath3 = StorePath(store, "invalid_order")
     with pytest.raises(TypeError):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -5,17 +5,16 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
-from zarr import Array, AsyncArray, config
+from zarr import Array, AsyncArray, config, create_array
+from zarr.api.asynchronous import create_array as create_async_array
 from zarr.codecs import (
-    BytesCodec,
-    ShardingCodec,
     TransposeCodec,
 )
 from zarr.core.buffer import default_buffer_prototype
+from zarr.core.chunk_key_encodings import ChunkKeyEncodingParams
 from zarr.storage import StorePath
 
 if TYPE_CHECKING:
-    from zarr.abc.codec import Codec
     from zarr.abc.store import Store
     from zarr.core.buffer.core import NDArrayLike
     from zarr.core.common import MemoryOrder
@@ -73,32 +72,17 @@ async def test_order(
     data = np.arange(0, 256, dtype="uint16").reshape((32, 8), order=input_order)
     path = "order"
     spath = StorePath(store, path=path)
-    codecs_: list[Codec] = (
-        [
-            ShardingCodec(
-                chunk_shape=(16, 8),
-                codecs=[
-                    TransposeCodec(order=order_from_dim(store_order, data.ndim)),
-                    BytesCodec(),
-                ],
-            )
-        ]
-        if with_sharding
-        else [
-            TransposeCodec(order=order_from_dim(store_order, data.ndim)),
-            BytesCodec(),
-        ]
-    )
 
     with config.set({"array.order": runtime_write_order}):
-        a = await AsyncArray.create(
+        a = await create_async_array(
             spath,
             shape=data.shape,
-            chunk_shape=(32, 8),
+            chunks=(32, 8),
+            shards=(16, 8) if with_sharding else None,
             dtype=data.dtype,
             fill_value=0,
-            chunk_key_encoding=("v2", "."),
-            codecs=codecs_,
+            chunk_key_encoding=ChunkKeyEncodingParams(name="v2", separator="."),
+            filters=[TransposeCodec(order=order_from_dim(store_order, data.ndim))],
         )
 
     await _AsyncArrayProxy(a)[:, :].set(data)
@@ -135,18 +119,15 @@ def test_order_implicit(
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16), order=input_order)
     path = "order_implicit"
     spath = StorePath(store, path)
-    codecs_: list[Codec] | None = (
-        [ShardingCodec(chunk_shape=(8, 8))] if with_sharding else None
-    )
 
     with config.set({"array.order": runtime_write_order}):
-        a = Array.create(
+        a = create_array(
             spath,
             shape=data.shape,
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
+            shards=(8, 8) if with_sharding else None,
             dtype=data.dtype,
             fill_value=0,
-            codecs=codecs_,
         )
 
     a[:, :] = data
@@ -167,10 +148,10 @@ def test_order_implicit(
 def test_write_partial_chunks(store: Store) -> None:
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=data.shape,
-        chunk_shape=(20, 20),
+        chunks=(20, 20),
         dtype=data.dtype,
         fill_value=1,
     )
@@ -182,10 +163,10 @@ async def test_delete_empty_chunks(store: Store) -> None:
     data = np.ones((16, 16))
     path = "delete_empty_chunks"
     spath = StorePath(store, path)
-    a = await AsyncArray.create(
+    a = await create_async_array(
         spath,
         shape=data.shape,
-        chunk_shape=(32, 32),
+        chunks=(32, 32),
         dtype=data.dtype,
         fill_value=1,
     )
@@ -199,39 +180,37 @@ def test_invalid_metadata(store: Store) -> None:
     # LD: Disabled for `zarrs`. Including endianness for a single-byte data type is not invalid.
     # spath2 = StorePath(store, "invalid_endian")
     # with pytest.raises(TypeError):
-    #     Array.create(
+    #     create_array(
     #         spath2,
     #         shape=(16, 16),
-    #         chunk_shape=(16, 16),
+    #         chunks=(16, 16),
     #         dtype=np.dtype("uint8"),
     #         fill_value=0,
-    #         codecs=[
-    #             BytesCodec(endian="big"),
+    #         filters=[
     #             TransposeCodec(order=order_from_dim("F", 2)),
     #         ],
     #     )
     spath3 = StorePath(store, "invalid_order")
     with pytest.raises(TypeError):
-        Array.create(
+        create_array(
             spath3,
             shape=(16, 16),
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=np.dtype("uint8"),
             fill_value=0,
-            codecs=[
-                BytesCodec(),
+            filters=[
                 TransposeCodec(order="F"),  # type: ignore[arg-type]
             ],
         )
     spath4 = StorePath(store, "invalid_missing_bytes_codec")
     with pytest.raises(ValueError, match=r".*[Cc]odec.*required"):
-        Array.create(
+        create_array(
             spath4,
             shape=(16, 16),
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
             dtype=np.dtype("uint8"),
             fill_value=0,
-            codecs=[
+            filters=[
                 TransposeCodec(order=order_from_dim("F", 2)),
             ],
         )
@@ -239,44 +218,38 @@ def test_invalid_metadata(store: Store) -> None:
     with pytest.raises(
         ValueError, match=r".*shard.*chunk_shape.*array.*shape.*need.*same.*dimensions"
     ):
-        Array.create(
+        create_array(
             spath5,
             shape=(16, 16),
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
+            shards=(8,),
             dtype=np.dtype("uint8"),
             fill_value=0,
-            codecs=[
-                ShardingCodec(chunk_shape=(8,)),
-            ],
         )
     spath6 = StorePath(store, "invalid_inner_chunk_shape")
     with pytest.raises(
         ValueError, match=r".*array.*chunk_shape.*divisible.*shard.*chunk_shape"
     ):
-        Array.create(
+        create_array(
             spath6,
             shape=(16, 16),
-            chunk_shape=(16, 16),
+            chunks=(16, 16),
+            shards=(8, 7),
             dtype=np.dtype("uint8"),
             fill_value=0,
-            codecs=[
-                ShardingCodec(chunk_shape=(8, 7)),
-            ],
         )
     # LD: Disabled for `zarrs`. Such checks do not exist.
     #     Also this is not invalid metadata, should be a separate test.
     # spath7 = StorePath(store, "warning_inefficient_codecs")
     # with pytest.warns(UserWarning):
-    #     Array.create(
+    #     create_array(
     #         spath7,
     #         shape=(16, 16),
-    #         chunk_shape=(16, 16),
+    #         chunks=(16, 16),
+    #         shards=(8, 8),
     #         dtype=np.dtype("uint8"),
     #         fill_value=0,
-    #         codecs=[
-    #             ShardingCodec(chunk_shape=(8, 8)),
-    #             GzipCodec(),
-    #         ],
+    #         compressors=[GzipCodec()],
     #     )
 
 
@@ -284,12 +257,12 @@ async def test_resize(store: Store) -> None:
     data = np.zeros((16, 18), dtype="uint16")
     path = "resize"
     spath = StorePath(store, path)
-    a = await AsyncArray.create(
+    a = await create_async_array(
         spath,
         shape=data.shape,
-        chunk_shape=(10, 10),
+        chunks=(10, 10),
         dtype=data.dtype,
-        chunk_key_encoding=("v2", "."),
+        chunk_key_encoding=ChunkKeyEncodingParams(name="v2", separator="."),
         fill_value=1,
     )
 

--- a/tests/test_endian.py
+++ b/tests/test_endian.py
@@ -2,9 +2,10 @@ from typing import Literal
 
 import numpy as np
 import pytest
-from zarr import AsyncArray
 from zarr.abc.store import Store
+from zarr.api.asynchronous import create_array as create_async_array
 from zarr.codecs import BytesCodec
+from zarr.core.chunk_key_encodings import ChunkKeyEncodingParams
 from zarr.storage import StorePath
 
 from .test_codecs import _AsyncArrayProxy
@@ -15,14 +16,14 @@ async def test_endian(store: Store, endian: Literal["big", "little"]) -> None:
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
     path = "endian"
     spath = StorePath(store, path)
-    a = await AsyncArray.create(
+    a = await create_async_array(
         spath,
         shape=data.shape,
-        chunk_shape=(16, 16),
+        chunks=(16, 16),
         dtype=data.dtype,
         fill_value=0,
-        chunk_key_encoding=("v2", "."),
-        codecs=[BytesCodec(endian=endian)],
+        chunk_key_encoding=ChunkKeyEncodingParams(name="v2", separator="."),
+        serializer=BytesCodec(endian=endian),
     )
 
     await _AsyncArrayProxy(a)[:, :].set(data)
@@ -40,14 +41,14 @@ async def test_endian_write(
     data = np.arange(0, 256, dtype=dtype_input_endian).reshape((16, 16))
     path = "endian"
     spath = StorePath(store, path)
-    a = await AsyncArray.create(
+    a = await create_async_array(
         spath,
         shape=data.shape,
-        chunk_shape=(16, 16),
+        chunks=(16, 16),
         dtype="uint16",
         fill_value=0,
-        chunk_key_encoding=("v2", "."),
-        codecs=[BytesCodec(endian=dtype_store_endian)],
+        chunk_key_encoding=ChunkKeyEncodingParams(name="v2", separator="."),
+        serializer=BytesCodec(endian=dtype_store_endian),
     )
 
     await _AsyncArrayProxy(a)[:, :].set(data)

--- a/tests/test_gzip.py
+++ b/tests/test_gzip.py
@@ -1,20 +1,20 @@
 import numpy as np
-from zarr import Array
+from zarr import create_array
 from zarr.abc.store import Store
-from zarr.codecs import BytesCodec, GzipCodec
+from zarr.codecs import GzipCodec
 from zarr.storage import StorePath
 
 
 def test_gzip(store: Store) -> None:
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
 
-    a = Array.create(
+    a = create_array(
         StorePath(store),
         shape=data.shape,
-        chunk_shape=(16, 16),
+        chunks=(16, 16),
         dtype=data.dtype,
         fill_value=0,
-        codecs=[BytesCodec(), GzipCodec()],
+        compressors=[GzipCodec()],
     )
 
     a[:, :] = data

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -276,6 +276,7 @@ async def test_delete_empty_shards(store: Store) -> None:
         shards=(8, 16),
         dtype="uint16",
         fill_value=1,
+        compressors=[],
     )
     await _AsyncArrayProxy(a)[:, :].set(np.zeros((16, 16)))
     await _AsyncArrayProxy(a)[8:, :].set(np.ones((8, 16)))

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -3,15 +3,16 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 import pytest
-from zarr import Array, AsyncArray
+from zarr import create_array
 from zarr.abc.store import Store
+from zarr.api.asynchronous import create_array as create_async_array
 from zarr.codecs import (
     BloscCodec,
-    BytesCodec,
     ShardingCodec,
     ShardingCodecIndexLocation,
     TransposeCodec,
 )
+from zarr.core.array import ShardsConfigParam
 from zarr.core.buffer import default_buffer_prototype
 from zarr.storage import StorePath
 
@@ -42,23 +43,17 @@ def test_sharding(
     """
     data = array_fixture
     spath = StorePath(store)
-    arr = Array.create(
+    arr = create_array(
         spath,
         shape=tuple(s + offset for s in data.shape),
-        chunk_shape=(64,) * data.ndim,
+        chunks=(64,) * data.ndim,
+        shards=ShardsConfigParam(
+            shape=(32,) * data.ndim, index_location=index_location
+        ),
         dtype=data.dtype,
         fill_value=6,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(32,) * data.ndim,
-                codecs=[
-                    TransposeCodec(order=order_from_dim("F", data.ndim)),
-                    BytesCodec(),
-                    BloscCodec(cname="lz4"),
-                ],
-                index_location=index_location,
-            )
-        ],
+        filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
+        compressors=[BloscCodec(cname="lz4")],
     )
     write_region = tuple(slice(offset, None) for dim in range(data.ndim))
     arr[write_region] = data
@@ -87,23 +82,15 @@ def test_sharding_partial(
 ) -> None:
     data = array_fixture
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=tuple(a + 10 for a in data.shape),
-        chunk_shape=(64, 64, 64),
+        chunks=(64, 64, 64),
+        shards=ShardsConfigParam(shape=(32, 32, 32), index_location=index_location),
         dtype=data.dtype,
         fill_value=0,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(32, 32, 32),
-                codecs=[
-                    TransposeCodec(order=order_from_dim("F", data.ndim)),
-                    BytesCodec(),
-                    BloscCodec(cname="lz4"),
-                ],
-                index_location=index_location,
-            )
-        ],
+        filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
+        compressors=[BloscCodec(cname="lz4")],
     )
 
     a[10:, 10:, 10:] = data
@@ -131,19 +118,15 @@ def test_sharding_partial_readwrite(
 ) -> None:
     data = array_fixture
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=data.shape,
-        chunk_shape=data.shape,
+        chunks=data.shape,
+        shards=ShardsConfigParam(
+            shape=(1, data.shape[1], data.shape[2]), index_location=index_location
+        ),
         dtype=data.dtype,
         fill_value=0,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(1, data.shape[1], data.shape[2]),
-                codecs=[BytesCodec()],
-                index_location=index_location,
-            )
-        ],
     )
 
     a[:] = data
@@ -171,23 +154,15 @@ def test_sharding_partial_read(
 ) -> None:
     data = array_fixture
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=tuple(a + 10 for a in data.shape),
-        chunk_shape=(64, 64, 64),
+        chunks=(64, 64, 64),
+        shards=ShardsConfigParam(shape=(32, 32, 32), index_location=index_location),
         dtype=data.dtype,
         fill_value=1,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(32, 32, 32),
-                codecs=[
-                    TransposeCodec(order=order_from_dim("F", data.ndim)),
-                    BytesCodec(),
-                    BloscCodec(cname="lz4"),
-                ],
-                index_location=index_location,
-            )
-        ],
+        filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
+        compressors=[BloscCodec(cname="lz4")],
     )
 
     read_data = a[0:10, 0:10, 0:10]
@@ -209,23 +184,15 @@ def test_sharding_partial_overwrite(
 ) -> None:
     data = array_fixture[:10, :10, :10]
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=tuple(a + 10 for a in data.shape),
-        chunk_shape=(64, 64, 64),
+        chunks=(64, 64, 64),
+        shards=ShardsConfigParam(shape=(32, 32, 32), index_location=index_location),
         dtype=data.dtype,
         fill_value=1,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(32, 32, 32),
-                codecs=[
-                    TransposeCodec(order=order_from_dim("F", data.ndim)),
-                    BytesCodec(),
-                    BloscCodec(cname="lz4"),
-                ],
-                index_location=index_location,
-            )
-        ],
+        filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
+        compressors=[BloscCodec(cname="lz4")],
     )
 
     a[:10, :10, :10] = data
@@ -262,23 +229,18 @@ def test_nested_sharding(
 ) -> None:
     data = array_fixture
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=data.shape,
-        chunk_shape=(64, 64, 64),
+        chunks=(64, 64, 64),
+        shards=ShardsConfigParam(
+            shape=(32, 32, 32), index_location=outer_index_location
+        ),
         dtype=data.dtype,
         fill_value=0,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(32, 32, 32),
-                codecs=[
-                    ShardingCodec(
-                        chunk_shape=(16, 16, 16), index_location=inner_index_location
-                    )
-                ],
-                index_location=outer_index_location,
-            )
-        ],
+        serializer=ShardingCodec(
+            chunk_shape=(16, 16, 16), index_location=inner_index_location
+        ),
     )
 
     a[:, :, :] = data
@@ -291,21 +253,14 @@ def test_nested_sharding(
 def test_write_partial_sharded_chunks(store: Store) -> None:
     data = np.arange(0, 16 * 16, dtype="uint16").reshape((16, 16))
     spath = StorePath(store)
-    a = Array.create(
+    a = create_array(
         spath,
         shape=(40, 40),
-        chunk_shape=(20, 20),
+        chunks=(20, 20),
+        shards=(10, 10),
         dtype=data.dtype,
         fill_value=1,
-        codecs=[
-            ShardingCodec(
-                chunk_shape=(10, 10),
-                codecs=[
-                    BytesCodec(),
-                    BloscCodec(),
-                ],
-            )
-        ],
+        compressors=[BloscCodec()],
     )
     a[0:16, 0:16] = data
     assert np.array_equal(a[0:16, 0:16], data)
@@ -316,13 +271,13 @@ async def test_delete_empty_shards(store: Store) -> None:
         pytest.skip("store does not support deletes")
     path = "delete_empty_shards"
     spath = StorePath(store, path)
-    a = await AsyncArray.create(
+    a = create_async_array(
         spath,
         shape=(16, 16),
-        chunk_shape=(8, 16),
+        chunks=(8, 16),
+        shards=(8, 8),
         dtype="uint16",
         fill_value=1,
-        codecs=[ShardingCodec(chunk_shape=(8, 8))],
     )
     await _AsyncArrayProxy(a)[:, :].set(np.zeros((16, 16)))
     await _AsyncArrayProxy(a)[8:, :].set(np.ones((8, 16)))
@@ -354,13 +309,13 @@ async def test_sharding_with_empty_inner_chunk(
 
     path = f"sharding_with_empty_inner_chunk_{index_location}"
     spath = StorePath(store, path)
-    a = await AsyncArray.create(
+    a = await create_async_array(
         spath,
         shape=(16, 16),
-        chunk_shape=(8, 8),
+        chunks=(8, 8),
+        shards=ShardsConfigParam(shape=(4, 4), index_location=index_location),
         dtype="uint32",
         fill_value=fill_value,
-        codecs=[ShardingCodec(chunk_shape=(4, 4), index_location=index_location)],
     )
     data[:4, :4] = fill_value
     await a.setitem(..., data)

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any
 
 import numpy as np
@@ -14,6 +15,7 @@ from zarr.codecs import (
 )
 from zarr.core.array import ShardsConfigParam
 from zarr.core.buffer import default_buffer_prototype
+from zarr.errors import ZarrUserWarning
 from zarr.storage import StorePath
 
 from .conftest import ArrayRequest
@@ -46,9 +48,9 @@ def test_sharding(
     arr = create_array(
         spath,
         shape=tuple(s + offset for s in data.shape),
-        chunks=(64,) * data.ndim,
+        chunks=(32,) * data.ndim,
         shards=ShardsConfigParam(
-            shape=(32,) * data.ndim, index_location=index_location
+            shape=(64,) * data.ndim, index_location=index_location
         ),
         dtype=data.dtype,
         fill_value=6,
@@ -85,8 +87,8 @@ def test_sharding_partial(
     a = create_array(
         spath,
         shape=tuple(a + 10 for a in data.shape),
-        chunks=(64, 64, 64),
-        shards=ShardsConfigParam(shape=(32, 32, 32), index_location=index_location),
+        chunks=(32, 32, 32),
+        shards=ShardsConfigParam(shape=(64, 64, 64), index_location=index_location),
         dtype=data.dtype,
         fill_value=0,
         filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
@@ -121,10 +123,8 @@ def test_sharding_partial_readwrite(
     a = create_array(
         spath,
         shape=data.shape,
-        chunks=data.shape,
-        shards=ShardsConfigParam(
-            shape=(1, data.shape[1], data.shape[2]), index_location=index_location
-        ),
+        chunks=(1, data.shape[1], data.shape[2]),
+        shards=ShardsConfigParam(shape=data.shape, index_location=index_location),
         dtype=data.dtype,
         fill_value=0,
     )
@@ -157,8 +157,8 @@ def test_sharding_partial_read(
     a = create_array(
         spath,
         shape=tuple(a + 10 for a in data.shape),
-        chunks=(64, 64, 64),
-        shards=ShardsConfigParam(shape=(32, 32, 32), index_location=index_location),
+        chunks=(32, 32, 32),
+        shards=ShardsConfigParam(shape=(64, 64, 64), index_location=index_location),
         dtype=data.dtype,
         fill_value=1,
         filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
@@ -187,8 +187,8 @@ def test_sharding_partial_overwrite(
     a = create_array(
         spath,
         shape=tuple(a + 10 for a in data.shape),
-        chunks=(64, 64, 64),
-        shards=ShardsConfigParam(shape=(32, 32, 32), index_location=index_location),
+        chunks=(32, 32, 32),
+        shards=ShardsConfigParam(shape=(64, 64, 64), index_location=index_location),
         dtype=data.dtype,
         fill_value=1,
         filters=[TransposeCodec(order=order_from_dim("F", data.ndim))],
@@ -213,14 +213,8 @@ def test_sharding_partial_overwrite(
     ],
     indirect=["array_fixture"],
 )
-@pytest.mark.parametrize(
-    "outer_index_location",
-    ["start", "end"],
-)
-@pytest.mark.parametrize(
-    "inner_index_location",
-    ["start", "end"],
-)
+@pytest.mark.parametrize("outer_index_location", ["start", "end"])
+@pytest.mark.parametrize("inner_index_location", ["start", "end"])
 def test_nested_sharding(
     store: Store,
     array_fixture: npt.NDArray[Any],
@@ -229,17 +223,21 @@ def test_nested_sharding(
 ) -> None:
     data = array_fixture
     spath = StorePath(store)
+    warnings.filterwarnings("ignore", r".*performance", ZarrUserWarning)
     a = create_array(
         spath,
         shape=data.shape,
         chunks=(64, 64, 64),
-        shards=ShardsConfigParam(
-            shape=(32, 32, 32), index_location=outer_index_location
-        ),
         dtype=data.dtype,
         fill_value=0,
         serializer=ShardingCodec(
-            chunk_shape=(16, 16, 16), index_location=inner_index_location
+            chunk_shape=(32, 32, 32),
+            index_location=outer_index_location,
+            codecs=[
+                ShardingCodec(
+                    chunk_shape=(16, 16, 16), index_location=inner_index_location
+                )
+            ],
         ),
     )
 
@@ -256,8 +254,8 @@ def test_write_partial_sharded_chunks(store: Store) -> None:
     a = create_array(
         spath,
         shape=(40, 40),
-        chunks=(20, 20),
-        shards=(10, 10),
+        chunks=(10, 10),
+        shards=(20, 20),
         dtype=data.dtype,
         fill_value=1,
         compressors=[BloscCodec()],
@@ -271,11 +269,11 @@ async def test_delete_empty_shards(store: Store) -> None:
         pytest.skip("store does not support deletes")
     path = "delete_empty_shards"
     spath = StorePath(store, path)
-    a = create_async_array(
+    a = await create_async_array(
         spath,
         shape=(16, 16),
-        chunks=(8, 16),
-        shards=(8, 8),
+        chunks=(8, 8),
+        shards=(8, 16),
         dtype="uint16",
         fill_value=1,
     )
@@ -295,7 +293,7 @@ async def test_delete_empty_shards(store: Store) -> None:
     )
     chunk_bytes = await store.get(f"{path}/c/0/0", prototype=default_buffer_prototype())
     assert chunk_bytes is not None
-    assert len(chunk_bytes) == 16 * 2 + 8 * 8 * 2 + 4
+    assert len(chunk_bytes) == 16 * 2 + 8 * 8 * 2 + 4 == 164
 
 
 @pytest.mark.parametrize(
@@ -312,8 +310,8 @@ async def test_sharding_with_empty_inner_chunk(
     a = await create_async_array(
         spath,
         shape=(16, 16),
-        chunks=(8, 8),
-        shards=ShardsConfigParam(shape=(4, 4), index_location=index_location),
+        chunks=(4, 4),
+        shards=ShardsConfigParam(shape=(8, 8), index_location=index_location),
         dtype="uint32",
         fill_value=fill_value,
     )

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -1,17 +1,14 @@
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pytest
-from zarr import Array, AsyncArray, config
+from zarr import AsyncArray, config, create_array
 from zarr.abc.store import Store
-from zarr.codecs import BytesCodec, ShardingCodec, TransposeCodec
+from zarr.api.asynchronous import create_array as create_async_array
+from zarr.codecs import TransposeCodec
+from zarr.core.chunk_key_encodings import ChunkKeyEncodingParams
 from zarr.core.common import MemoryOrder
 from zarr.storage import StorePath
 
 from .test_codecs import _AsyncArrayProxy
-
-if TYPE_CHECKING:
-    from zarr.abc.codec import Codec
 
 
 @pytest.mark.parametrize("input_order", ["F", "C"])
@@ -28,25 +25,15 @@ async def test_transpose(
 ) -> None:
     data = np.arange(0, 256, dtype="uint16").reshape((1, 32, 8), order=input_order)
     spath = StorePath(store, path="transpose")
-    codecs_: list[Codec] = (
-        [
-            ShardingCodec(
-                chunk_shape=(1, 16, 8),
-                codecs=[TransposeCodec(order=(2, 1, 0)), BytesCodec()],
-            )
-        ]
-        if with_sharding
-        else [TransposeCodec(order=(2, 1, 0)), BytesCodec()]
-    )
     with config.set({"array.order": runtime_write_order}):
-        a = await AsyncArray.create(
+        a = await create_async_array(
             spath,
             shape=data.shape,
-            chunk_shape=(1, 32, 8),
+            shards=(1, 32, 8) if with_sharding else None,
             dtype=data.dtype,
             fill_value=0,
-            chunk_key_encoding=("v2", "."),
-            codecs=codecs_,
+            chunk_key_encoding=ChunkKeyEncodingParams(name="v2", separator="."),
+            filters=[TransposeCodec(order=(2, 1, 0))],
         )
 
     await _AsyncArrayProxy(a)[:, :].set(data)
@@ -73,13 +60,13 @@ def test_transpose_non_self_inverse(store: Store, order: list[int]) -> None:
     shape = [i + 3 for i in range(len(order))]
     data = np.arange(0, np.prod(shape), dtype="uint16").reshape(shape)
     spath = StorePath(store, "transpose_non_self_inverse")
-    a = Array.create(
+    a = create_array(
         spath,
         shape=data.shape,
-        chunk_shape=data.shape,
+        chunks=data.shape,
         dtype=data.dtype,
         fill_value=0,
-        codecs=[TransposeCodec(order=order), BytesCodec()],
+        filters=[TransposeCodec(order=order)],
     )
     a[:, :] = data
     read_data = a[:, :]

--- a/tests/test_zstd.py
+++ b/tests/test_zstd.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
-from zarr import Array
+from zarr import create_array
 from zarr.abc.store import Store
-from zarr.codecs import BytesCodec, ZstdCodec
+from zarr.codecs import ZstdCodec
 from zarr.storage import StorePath
 
 
@@ -10,13 +10,13 @@ from zarr.storage import StorePath
 def test_zstd(*, store: Store, checksum: bool) -> None:
     data = np.arange(0, 256, dtype="uint16").reshape((16, 16))
 
-    a = Array.create(
+    a = create_array(
         StorePath(store, path="zstd"),
         shape=data.shape,
-        chunk_shape=(16, 16),
+        chunks=(16, 16),
         dtype=data.dtype,
         fill_value=0,
-        codecs=[BytesCodec(), ZstdCodec(level=0, checksum=checksum)],
+        compressors=[ZstdCodec(level=0, checksum=checksum)],
     )
 
     a[:, :] = data


### PR DESCRIPTION
so what I thought happens is that they split up `codecs` into

1. `shards`: if present, this contains the parameters for an implicitly created `ArrayToArrayCodec` that wraps all other given codecs and applies them for each shard individually
2. `filters`: list of `ArrayToArrayCodec`s
3. `serializer`: a single `ArrayToBytesCodec`
4. `compressors`: a list of `BytesToBytesCodec`s

this assumption seems to hold for e.g. `tests/test_codecs.py::test_order`, but other tests  fail, so apparently I didn’t understand this.