### PR TITLE
feat: expose fd cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The `ZarrsCodecPipeline` specific options are:
   - Defaults to 4 if `None`. See [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#chunk-concurrent-minimum) for more info.
 - `codec_pipeline.validate_checksums`: enable checksum validation (e.g. with the CRC32C codec).
   - Defaults to `True`. See [here](https://docs.rs/zarrs/latest/zarrs/config/struct.Config.html#validate-checksums) for more info.
+- `codec_pipeline.file_handle_cache_size`: the capacity of the filesystem store's file handle cache. If nonzero, files are kept open in a least-recently-used cache and reused across partial reads instead of being reopened per read, which cuts `open`/`stat`/`close` operations when many byte ranges are read from the same files, such as partial reads of sharded arrays. This is particularly beneficial on network filesystems (e.g. Lustre, NFS), where each metadata operation is a server round trip.
+  - Defaults to `0` (disabled). Only applies to filesystem stores, and has no effect when `direct_io` is enabled.
+  - Cached handles are invalidated on writes through this pipeline, but not on modification from anywhere else — and `zarr-python` itself is such a writer, since `resize`, `delete_dir` and metadata writes go through its own store. A cached handle can then still read a chunk file that has been deleted. Only enable this while nothing is modifying the array.
+  - The cache is per `Array` object, not per process, so compare `file_handle_cache_size` times the number of open arrays against `ulimit -n`. See [here](https://docs.rs/zarrs_filesystem/latest/zarrs_filesystem/struct.FilesystemStoreOptions.html#method.file_handle_cache_size) for more info.
 - `codec_pipeline.direct_io`: enable `O_DIRECT` read/write, needs support from the operating system (currently only Linux) and file system.
   - Defaults to `False`.
 - `codec_pipeline.strict`: raise exceptions for unsupported operations instead of falling back to the default codec pipeline of `zarr-python`.
@@ -62,6 +66,7 @@ zarr.config.set({
         "validate_checksums": True,
         "chunk_concurrent_maximum": None,
         "chunk_concurrent_minimum": 4,
+        "file_handle_cache_size": 0,
         "direct_io": False,
         "strict": False
     }

--- a/python/zarrs/_internal.pyi
+++ b/python/zarrs/_internal.pyi
@@ -30,6 +30,7 @@ class CodecPipelineImpl:
         chunk_concurrent_maximum: builtins.int | None = None,
         num_threads: builtins.int | None = None,
         direct_io: builtins.bool = False,
+        file_handle_cache_size: builtins.int = 0,
     ) -> CodecPipelineImpl: ...
     def retrieve_chunks_and_apply_index(
         self,

--- a/python/zarrs/pipeline.py
+++ b/python/zarrs/pipeline.py
@@ -62,6 +62,9 @@ def get_codec_pipeline_impl(
             ),
             num_threads=config.get("threading.max_workers", None),
             direct_io=config.get("codec_pipeline.direct_io", False),
+            file_handle_cache_size=config.get(
+                "codec_pipeline.file_handle_cache_size", 0
+            ),
         )
     except TypeError as e:
         if strict:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ impl CodecPipelineImpl {
         chunk_concurrent_maximum=None,
         num_threads=None,
         direct_io=false,
+        file_handle_cache_size=0,
     ))]
     #[new]
     fn new(
@@ -228,8 +229,10 @@ impl CodecPipelineImpl {
         chunk_concurrent_maximum: Option<usize>,
         num_threads: Option<usize>,
         direct_io: bool,
+        file_handle_cache_size: usize,
     ) -> PyResult<Self> {
         store_config.direct_io(direct_io);
+        store_config.file_handle_cache_size(file_handle_cache_size);
         let metadata = serde_json::from_str(array_metadata).map_py_err::<PyTypeError>()?;
         let metadata_v3 = match &metadata {
             ArrayMetadata::V2(v2) => {

--- a/src/store.rs
+++ b/src/store.rs
@@ -79,6 +79,14 @@ impl StoreConfig {
             StoreConfig::ObStore(_config) => (),
         }
     }
+
+    pub fn file_handle_cache_size(&mut self, size: usize) {
+        match self {
+            StoreConfig::Filesystem(config) => config.file_handle_cache_size(size),
+            StoreConfig::Http(_config) => (),
+            StoreConfig::ObStore(_config) => (),
+        }
+    }
 }
 
 impl pyo3_stub_gen::PyStubType for StoreConfig {

--- a/src/store/filesystem.rs
+++ b/src/store/filesystem.rs
@@ -25,6 +25,10 @@ impl FilesystemStoreConfig {
     pub fn direct_io(&mut self, flag: bool) -> () {
         self.opts.direct_io(flag);
     }
+
+    pub fn file_handle_cache_size(&mut self, size: usize) {
+        self.opts.file_handle_cache_size(size);
+    }
 }
 
 impl TryInto<ReadableWritableListableStorage> for &FilesystemStoreConfig {

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -128,3 +128,40 @@ def test_direct_io(tmp_path: Path) -> None:
     ground_truth_arr = np.random.random(z.shape)
     z[...] = ground_truth_arr
     np.testing.assert_array_equal(z[...], ground_truth_arr)
+
+
+def _open_fds() -> int:
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.is_dir():
+        fd_dir = Path("/dev/fd")
+    return len(list(fd_dir.iterdir()))
+
+
+def _sharded_array(path: Path) -> np.ndarray:
+    z = zarr.create_array(
+        path, dtype=np.float64, shape=(80, 100), chunks=(10, 10), shards=(20, 20)
+    )
+    ground_truth_arr = np.random.random(z.shape)
+    z[...] = ground_truth_arr
+    return ground_truth_arr
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows", reason="needs /proc/self/fd or /dev/fd"
+)
+@pytest.mark.parametrize("cache_size", [0, 4])
+def test_file_handle_cache(tmp_path: Path, cache_size: int) -> None:
+    path = tmp_path / "foo.zarr"
+    ground_truth_arr = _sharded_array(path)
+
+    with zarr.config.set(
+        {
+            "codec_pipeline.path": "zarrs.ZarrsCodecPipeline",
+            "codec_pipeline.file_handle_cache_size": cache_size,
+        }
+    ):
+        before = _open_fds()
+        z = zarr.open_array(path, mode="r")
+        np.testing.assert_array_equal(z[...], ground_truth_arr)
+        # Shard files stay open only while the cache is enabled.
+        assert _open_fds() - before == cache_size


### PR DESCRIPTION
Hi!

This file handler caching saves my life on some other performance optimization paths I am working on. So I think it makes sense that this is finally exposed.

- `zarrs_filesystem` has `FilesystemStoreOptions::file_handle_cache_size` since 0.3.11 (zarrs#422), but it is unreachable from Python: `FilesystemStoreConfig::opts` is private and only options with an explicit forwarding method can be set.


- The README notes the one zarr-python-specific caveat: the upstream option does not observe external modification.

- One question — the code uses an API added in `zarrs_filesystem` 0.3.11, but the manifest is unchanged, since `zarrs` requires `^0.3.9` and resolution picks 0.3.12. That means `-Z minimal-versions` fails. Happy to add `zarrs_filesystem = "0.3.11"` as a direct dependency if you would rather it were declared.